### PR TITLE
 chore: configure qwq for thinking

### DIFF
--- a/apps/api/src/lib/models/groq.ts
+++ b/apps/api/src/lib/models/groq.ts
@@ -30,6 +30,7 @@ export const groqModelConfig: ModelConfig = {
     strengths: ["chat", "general_knowledge", "analysis", "multilingual"],
     contextComplexity: 4,
     reliability: 4,
+    hasThinking: true,
   },
   "deepseek-r1-distill-qwen-32b": {
     name: "Groq DeepSeek R1 Distill Qwen 32B",

--- a/apps/api/src/lib/models/workersai.ts
+++ b/apps/api/src/lib/models/workersai.ts
@@ -322,6 +322,7 @@ export const workersAiModelConfig: ModelConfig = {
     speed: 3,
     reliability: 5,
     contextComplexity: 5,
+    hasThinking: true,
   },
   "qwen2.5-coder-32b": {
     name: "Qwen 2.5 Coder 32B",


### PR DESCRIPTION
- Add hasThinking: true to Workers AI QwQ 32B model configuration
- Add hasThinking: true to Groq QwQ 32B model configuration
- This enables proper native thinking support without conflicting prompt instructions
