### PR TITLE
feat: ingest uploaded files with bedrock knowledge base

### DIFF
--- a/apps/api/src/services/apps/embeddings/__test__/delete.test.ts
+++ b/apps/api/src/services/apps/embeddings/__test__/delete.test.ts
@@ -5,7 +5,7 @@ const mockDatabase = {
 };
 
 const mockEmbedding = {
-  delete: vi.fn(() => Promise.resolve({ status: "success" })),
+  delete: vi.fn(() => Promise.resolve({ status: "success", error: null })),
 };
 
 vi.mock("~/lib/database", () => ({
@@ -60,7 +60,7 @@ describe("deleteEmbedding", () => {
     };
 
     mockDatabase.getUserSettings.mockResolvedValue({});
-    mockEmbedding.delete.mockResolvedValue({ status: "success" });
+    mockEmbedding.delete.mockResolvedValue({ status: "success", error: null });
 
     const result = await deleteEmbedding(req);
 
@@ -88,7 +88,7 @@ describe("deleteEmbedding", () => {
     };
 
     mockDatabase.getUserSettings.mockResolvedValue({});
-    mockEmbedding.delete.mockResolvedValue({ status: "success" });
+    mockEmbedding.delete.mockResolvedValue({ status: "success", error: null });
 
     const result = await deleteEmbedding(req);
 
@@ -137,7 +137,7 @@ describe("deleteEmbedding", () => {
     };
 
     mockDatabase.getUserSettings.mockResolvedValue({});
-    mockEmbedding.delete.mockResolvedValue({ status: "success" });
+    mockEmbedding.delete.mockResolvedValue({ status: "success", error: null });
 
     const result = await deleteEmbedding(req);
 

--- a/apps/api/src/services/apps/embeddings/__test__/insert.test.ts
+++ b/apps/api/src/services/apps/embeddings/__test__/insert.test.ts
@@ -66,7 +66,7 @@ describe("insertEmbedding", () => {
     mockDatabase.getUserSettings.mockResolvedValue({});
     mockEmbedding.getNamespace.mockReturnValue("default-namespace");
     mockEmbedding.generate.mockResolvedValue([{ id: "vec-1" }]);
-    mockEmbedding.insert.mockResolvedValue({ status: "success" });
+    mockEmbedding.insert.mockResolvedValue({ status: "success", error: null });
     vi.mocked(chunkText).mockReturnValue(["single chunk"]);
     vi.mocked(generateId).mockReturnValue("generated-id");
   });
@@ -93,7 +93,7 @@ describe("insertEmbedding", () => {
     mockDatabase.getUserSettings.mockResolvedValue({});
     mockEmbedding.getNamespace.mockReturnValue("custom-ns");
     mockEmbedding.generate.mockResolvedValue([{ id: "vec-1" }]);
-    mockEmbedding.insert.mockResolvedValue({ status: "success" });
+    mockEmbedding.insert.mockResolvedValue({ status: "success", error: null });
 
     const result = await insertEmbedding(req);
 
@@ -134,7 +134,7 @@ describe("insertEmbedding", () => {
     mockDatabase.getEmbeddingIdByType.mockResolvedValue("blog-456");
     mockDatabase.getUserSettings.mockResolvedValue({});
     mockEmbedding.generate.mockResolvedValue([{ id: "vec-2" }]);
-    mockEmbedding.insert.mockResolvedValue({ status: "success" });
+    mockEmbedding.insert.mockResolvedValue({ status: "success", error: null });
 
     const result = await insertEmbedding(req);
 
@@ -222,7 +222,7 @@ describe("insertEmbedding", () => {
     mockDatabase.insertEmbedding.mockResolvedValue(undefined);
     mockDatabase.getUserSettings.mockResolvedValue({});
     mockEmbedding.generate.mockResolvedValue([{ id: "vec-1" }]);
-    mockEmbedding.insert.mockResolvedValue({ status: "success" });
+    mockEmbedding.insert.mockResolvedValue({ status: "success", error: null });
 
     const result = await insertEmbedding(req);
 
@@ -250,7 +250,7 @@ describe("insertEmbedding", () => {
     mockDatabase.insertEmbedding.mockResolvedValue(undefined);
     mockDatabase.getUserSettings.mockResolvedValue({});
     mockEmbedding.generate.mockResolvedValue([{ id: "vec-1" }]);
-    mockEmbedding.insert.mockResolvedValue({ status: "success" });
+    mockEmbedding.insert.mockResolvedValue({ status: "success", error: null });
 
     // @ts-ignore - req.request.id is required
     const result = await insertEmbedding(req);

--- a/apps/api/src/services/apps/embeddings/insert.ts
+++ b/apps/api/src/services/apps/embeddings/insert.ts
@@ -53,6 +53,25 @@ export const insertEmbedding = async (
     }
 
     let uniqueId;
+    // Metadata travels from the original upload request all the way through to
+    // the embedding provider. For file uploads the metadata object typically
+    // contains the public asset URL plus additional descriptors supplied by the
+    // upload service (see services/uploads). The current shape we rely on for
+    // Bedrock ingestion looks like:
+    // {
+    //   title: string;                // Added below for all documents
+    //   url?: string;                 // Public URL returned from handleFileUpload
+    //   fileUrl?: string;             // Some clients explicitly alias the URL
+    //   fileName?: string;            // Original filename supplied by the client
+    //   mimeType?: string;            // MIME type reported during upload
+    //   fileBase64?: string;          // Optional inline payload for direct ingest
+    //   storageKey?: string;          // Optional R2 key when known client side
+    //   chunkIndex?: string;          // Added when chunking in this service
+    //   [additional attributes]: any; // Free-form attributes preserved verbatim
+    // }
+    // The Bedrock embedding provider inspects these fields to decide whether a
+    // document should be sent as inline text (notes) or as a binary upload
+    // (files).
     const newMetadata = { ...metadata, title };
 
     const database = Database.getInstance(env);

--- a/apps/api/src/types/embeddings.ts
+++ b/apps/api/src/types/embeddings.ts
@@ -22,6 +22,8 @@ export type EmbeddingQueryResult = {
 export type EmbeddingMutationResult = {
   status: string;
   error: string | null;
+  documentDetails?: any;
+  documentIds?: string[];
 };
 
 export interface EmbeddingProvider {


### PR DESCRIPTION
## Summary
- document the upload metadata structure that flows into embeddings and extend the mutation result shape to surface document identifiers
- teach the Bedrock embedding provider to ingest binary uploads, reuse inline text for notes, and populate AWS ingestion metadata
- expand the Bedrock provider tests to cover file uploads while updating embedding service tests for the richer mutation response

## Testing
- pnpm vitest run apps/api/src/lib/embedding/__test__/bedrock.test.ts
- pnpm vitest run apps/api/src/services/apps/embeddings/__test__/delete.test.ts apps/api/src/services/apps/embeddings/__test__/insert.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68fd61e7224c832ab7e0da6efa712d0e