### PR TITLE
feat: standardize Replicate completions output

### DIFF
--- a/apps/api/src/lib/formatter/__test__/responses.test.ts
+++ b/apps/api/src/lib/formatter/__test__/responses.test.ts
@@ -7,26 +7,25 @@ const {
   mockUploadAudioFromChat,
   mockStorageService,
   mockBucket,
-} =
-  vi.hoisted(() => {
-    const mockUploadImageFromChat = vi.fn();
-    const mockUploadAudioFromChat = vi.fn();
-    const mockStorageService = {
-      uploadObject: vi.fn().mockResolvedValue("test-key"),
-      getObject: vi.fn(),
-    };
-    const mockBucket = {
-      put: vi.fn().mockResolvedValue(undefined),
-      get: vi.fn(),
-    };
+} = vi.hoisted(() => {
+  const mockUploadImageFromChat = vi.fn();
+  const mockUploadAudioFromChat = vi.fn();
+  const mockStorageService = {
+    uploadObject: vi.fn().mockResolvedValue("test-key"),
+    getObject: vi.fn(),
+  };
+  const mockBucket = {
+    put: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn(),
+  };
 
-    return {
-      mockUploadImageFromChat,
-      mockUploadAudioFromChat,
-      mockStorageService,
-      mockBucket,
-    };
-  });
+  return {
+    mockUploadImageFromChat,
+    mockUploadAudioFromChat,
+    mockStorageService,
+    mockBucket,
+  };
+});
 
 vi.mock("../storage", () => ({
   StorageService: vi.fn().mockImplementation(() => mockStorageService),
@@ -414,7 +413,9 @@ describe("ResponseFormatter", () => {
         mockBucket.put.mock.calls.length;
       expect(storageCalls).toBeGreaterThan(0);
       const responseUrl = (result.response as any)[0].image_url.url as string;
-      expect(responseUrl.startsWith(mockEnv.PUBLIC_ASSETS_URL || "")).toBe(true);
+      expect(responseUrl.startsWith(mockEnv.PUBLIC_ASSETS_URL || "")).toBe(
+        true,
+      );
       expect(result.data.assets[0].originalUrl).toBe(
         "https://replicate.delivery/example/output-0.png",
       );

--- a/apps/api/src/lib/formatter/responses.ts
+++ b/apps/api/src/lib/formatter/responses.ts
@@ -590,8 +590,8 @@ export class ResponseFormatter {
       data?.response ??
       [];
 
-    const strings = ResponseFormatter.collectStringsFromOutput(output).map((value) =>
-      value.trim(),
+    const strings = ResponseFormatter.collectStringsFromOutput(output).map(
+      (value) => value.trim(),
     );
     const urlStrings = strings.filter((value) =>
       value.toLowerCase().startsWith("http"),
@@ -626,7 +626,8 @@ export class ResponseFormatter {
       }
 
       let persistedUrls = candidateUrls;
-      let metadata: Array<{ key: string; url: string; originalUrl: string }> = [];
+      let metadata: Array<{ key: string; url: string; originalUrl: string }> =
+        [];
 
       if (options.env?.ASSETS_BUCKET) {
         const uploads = await ResponseFormatter.persistRemoteAssets(
@@ -663,7 +664,8 @@ export class ResponseFormatter {
       }
 
       let persistedUrls = candidateUrls;
-      let metadata: Array<{ key: string; url: string; originalUrl: string }> = [];
+      let metadata: Array<{ key: string; url: string; originalUrl: string }> =
+        [];
 
       if (options.env?.ASSETS_BUCKET) {
         const uploads = await ResponseFormatter.persistRemoteAssets(
@@ -702,7 +704,8 @@ export class ResponseFormatter {
       }
 
       let persistedUrls = candidateUrls;
-      let metadata: Array<{ key: string; url: string; originalUrl: string }> = [];
+      let metadata: Array<{ key: string; url: string; originalUrl: string }> =
+        [];
 
       if (options.env?.ASSETS_BUCKET) {
         const uploads = await ResponseFormatter.persistRemoteAssets(


### PR DESCRIPTION
## Summary
- add a Replicate formatter that inspects prediction output and emits standardized message parts across text, image, audio, and video modalities
- add shared helpers to persist remote assets to storage when buckets are configured so Replicate URLs remain valid
- cover the new formatter behavior with unit tests exercising asset persistence and text/audio handling

## Testing
- pnpm --filter @assistant/api test -- --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68fec18b634c832aa87a64b01290efd3