### PR TITLE
Fix issues in object module

### DIFF
--- a/apps/mobile/ios/Polychat/ContentView.swift
+++ b/apps/mobile/ios/Polychat/ContentView.swift
@@ -10,8 +10,8 @@ struct ContentView: View {
             TabView(selection: $selectedTab) {
                 NavigationView {
                     ConversationListView()
-                        .onChange(of: conversationManager.currentConversation) { conversation in
-                            if conversation != nil {
+                        .onChange(of: conversationManager.currentConversation) {
+                            if conversationManager.currentConversation != nil {
                                 selectedTab = 1
                             }
                         }
@@ -23,7 +23,7 @@ struct ContentView: View {
                 .tag(0)
                 
                 NavigationView {
-                    if let currentConversation = conversationManager.currentConversation {
+                    if conversationManager.currentConversation != nil {
                         ChatView()
                     } else {
                         VStack {

--- a/apps/mobile/ios/Polychat/Intents/ChatIntent.swift
+++ b/apps/mobile/ios/Polychat/Intents/ChatIntent.swift
@@ -20,10 +20,10 @@ struct ChatIntent: AppIntent {
             ChatMessage(role: "user", content: prompt)
         ], modelId: "mistral-small")
         
-        guard let answer = response.choices.first?.message.content else {
+        guard let answer = response.choices.first?.message.content.textValue else {
             throw NSError(domain: "com.polychat.app", code: 1, userInfo: [NSLocalizedDescriptionKey: "No response from AI"])
         }
-        
+
         return .result(value: answer)
     }
 }

--- a/apps/mobile/ios/Polychat/Views/ChatView.swift
+++ b/apps/mobile/ios/Polychat/Views/ChatView.swift
@@ -84,7 +84,7 @@ struct ChatView: View {
                     .disabled(allArtifacts.isEmpty)
 
                     Button(action: {
-                        conversationManager.startNewConversation()
+                        _ = conversationManager.startNewConversation()
                     }) {
                         Image(systemName: "plus")
                     }
@@ -187,7 +187,7 @@ struct MessageListView: View {
                     }
                 }
                 .padding(.horizontal)
-                .onChange(of: messages.count) { _ in
+                .onChange(of: messages.count) {
                     if let lastMessageId = messages.last?.id {
                         withAnimation {
                             proxy.scrollTo(lastMessageId, anchor: .bottom)

--- a/apps/mobile/ios/Polychat/Views/ConversationListView.swift
+++ b/apps/mobile/ios/Polychat/Views/ConversationListView.swift
@@ -122,7 +122,7 @@ struct ConversationListView: View {
     }
 
     private func startNewConversation() {
-        conversationManager.startNewConversation()
+        _ = conversationManager.startNewConversation()
     }
 
     private func deleteConversations(from conversations: [Conversation], at offsets: IndexSet) {
@@ -143,7 +143,7 @@ struct ConversationRow: View {
         guard let lastMessage = conversation.messages.last(where: { $0.role == "user" || $0.role == "assistant" }) else {
             return "No messages yet"
         }
-        return lastMessage.content
+        return lastMessage.content.textValue
     }
 
     private var messageCount: Int {

--- a/apps/mobile/ios/Polychat/Views/ImagePickerView.swift
+++ b/apps/mobile/ios/Polychat/Views/ImagePickerView.swift
@@ -16,7 +16,7 @@ struct ImagePickerView: View {
                     .font(.system(size: 18))
             }
         }
-        .onChange(of: selectedItems) { _ in
+        .onChange(of: selectedItems) {
             loadImages()
         }
     }

--- a/apps/mobile/ios/Polychat/Views/ModelSelectorView.swift
+++ b/apps/mobile/ios/Polychat/Views/ModelSelectorView.swift
@@ -108,8 +108,8 @@ struct ModelSelectorView: View {
                 }
             }
         }
-        .onChange(of: modelsStore.error) { error in
-            showingError = error != nil
+        .onChange(of: modelsStore.error) { _, newValue in
+            showingError = newValue != nil
         }
     }
 }

--- a/apps/mobile/ios/Polychat/Views/SettingsView.swift
+++ b/apps/mobile/ios/Polychat/Views/SettingsView.swift
@@ -69,8 +69,8 @@ struct SettingsView: View {
             
             Section(header: Text("Chat Settings")) {
                 Toggle("Auto-generate titles", isOn: $autoTitleGeneration)
-                    .onChange(of: autoTitleGeneration) { value in
-                        UserDefaults.standard.set(value, forKey: "autoTitleGeneration")
+                    .onChange(of: autoTitleGeneration) { _, newValue in
+                        UserDefaults.standard.set(newValue, forKey: "autoTitleGeneration")
                     }
             }
             


### PR DESCRIPTION
…I usage

This commit fixes all critical errors and warnings in the iOS app:

Errors Fixed:
- Fix MessageContent type handling across the app by using .textValue property
  - ConversationManager.swift: Fixed content.prefix() and content type conversion
  - ConversationListView.swift: Fixed lastMessage.content return type
  - ChatIntent.swift: Fixed message.content type in response handling
- Properly capture and use title generation response instead of ignoring return value

Warnings Fixed:
- Add explicit discard of unused startNewConversation() return values
- Update deprecated onChange(of:perform:) to iOS 17+ syntax across all views:
  - ContentView.swift: Updated to zero-parameter closure
  - ImagePickerView.swift: Updated to zero-parameter closure
  - ChatView.swift: Updated to zero-parameter closure
  - SettingsView.swift: Updated to two-parameter closure (oldValue, newValue)
  - ModelSelectorView.swift: Updated to two-parameter closure
- Fix unused variable warning in ContentView by using nil check instead of if-let

The MessageContent enum can be either .text(String) or .multimodal([MessageContentBlock]), so we use the .textValue computed property to extract text content consistently.