### PR TITLE
Add legal links to iOS app settings

### DIFF
--- a/apps/mobile/ios/Polychat/Services/APIClient.swift
+++ b/apps/mobile/ios/Polychat/Services/APIClient.swift
@@ -17,6 +17,7 @@ class APIClient: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
@@ -49,6 +50,7 @@ class APIClient: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
@@ -72,6 +74,7 @@ class APIClient: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
@@ -109,6 +112,7 @@ class APIClient: ObservableObject {
         var request = URLRequest(url: urlComponents.url!)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
@@ -136,6 +140,7 @@ class APIClient: ObservableObject {
         var request = URLRequest(url: urlComponents.url!)
         request.httpMethod = "GET"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
@@ -159,6 +164,7 @@ class APIClient: ObservableObject {
         var request = URLRequest(url: url)
         request.httpMethod = "PUT"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }
@@ -182,6 +188,7 @@ class APIClient: ObservableObject {
         let url = URL(string: "\(baseURL)/chat/completions/\(id)")!
         var request = URLRequest(url: url)
         request.httpMethod = "DELETE"
+        request.setValue("mobile", forHTTPHeaderField: "X-Platform")
         if !apiKey.isEmpty {
             request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         }

--- a/apps/mobile/ios/Polychat/Views/ChatView.swift
+++ b/apps/mobile/ios/Polychat/Views/ChatView.swift
@@ -213,44 +213,56 @@ struct MessageInputView: View {
                     .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 
-            HStack(spacing: 12) {
+            HStack(alignment: .bottom, spacing: 12) {
                 ImagePickerView(selectedImages: $selectedImages)
                     .foregroundColor(.blue)
+                    .padding(.bottom, 8)
 
-                TextEditor(text: $messageText)
-                    .focused($isInputFocused)
-                    .frame(minHeight: 36, maxHeight: 120)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 8)
-                    .background(Color(.systemGray6))
-                    .clipShape(RoundedRectangle(cornerRadius: 18))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 18)
-                            .stroke(Color(.systemGray4), lineWidth: 1)
-                    )
-                    .onSubmit {
-                        sendMessage()
+                ZStack(alignment: .topLeading) {
+                    // Placeholder text
+                    if messageText.isEmpty {
+                        Text("Message...")
+                            .foregroundColor(Color(.systemGray3))
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 12)
                     }
 
+                    TextEditor(text: $messageText)
+                        .focused($isInputFocused)
+                        .scrollContentBackground(.hidden)
+                        .frame(minHeight: 40, maxHeight: 120)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                }
+                .background(Color(.systemGray6))
+                .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20, style: .continuous)
+                        .stroke(isInputFocused ? Color.blue.opacity(0.3) : Color(.systemGray4), lineWidth: isInputFocused ? 2 : 1)
+                )
+
                 Button(action: sendMessage) {
-                    Image(systemName: "paperplane.fill")
-                        .font(.system(size: 20))
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 18, weight: .semibold))
                         .foregroundColor(.white)
-                        .frame(width: 36, height: 36)
+                        .frame(width: 32, height: 32)
                         .background((messageText.isEmpty && selectedImages.isEmpty) ? Color.gray : Color.blue)
                         .clipShape(Circle())
                 }
                 .disabled(messageText.isEmpty && selectedImages.isEmpty)
+                .padding(.bottom, 8)
             }
-            .padding()
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
         }
         .background(Color(.systemBackground))
         .overlay(
             Rectangle()
-                .frame(height: 1)
-                .foregroundColor(Color(.systemGray5)),
+                .frame(height: 0.5)
+                .foregroundColor(Color(.systemGray4)),
             alignment: .top
         )
+        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: -2)
     }
 }
 

--- a/apps/mobile/ios/Polychat/Views/ConversationListView.swift
+++ b/apps/mobile/ios/Polychat/Views/ConversationListView.swift
@@ -68,6 +68,8 @@ struct ConversationListView: View {
                                 )
                             }
                             .buttonStyle(PlainButtonStyle())
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                            .listRowBackground(Color.clear)
                         }
                         .onDelete { offsets in
                             deleteConversations(from: conversations, at: offsets)
@@ -89,8 +91,10 @@ struct ConversationListView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 40)
+                    .listRowBackground(Color.clear)
                 }
             }
+            .listStyle(.plain)
             .refreshable {
                 await conversationManager.refreshConversations()
             }
@@ -193,7 +197,13 @@ struct ConversationRow: View {
                 }
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, 8)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 0)
+                .fill(isSelected ? Color.blue.opacity(0.05) : Color(.systemBackground))
+        )
+        .contentShape(Rectangle())
     }
 
     private func relativeDate(from date: Date) -> String {

--- a/apps/mobile/ios/Polychat/Views/SettingsView.swift
+++ b/apps/mobile/ios/Polychat/Views/SettingsView.swift
@@ -5,6 +5,9 @@ struct SettingsView: View {
     @EnvironmentObject var modelsStore: ModelsStore
     @State private var showingModelSelector = false
     @State private var autoTitleGeneration = true
+    @State private var showingPrivacyPolicy = false
+    @State private var showingTerms = false
+    @State private var showingHelp = false
     
     var body: some View {
         List {
@@ -86,15 +89,44 @@ struct SettingsView: View {
                 }
             }
             
-            Section(header: Text("About")) {
-                NavigationLink("Privacy Policy") {
-                    Text("Privacy Policy Content")
+            Section(header: Text("Legal")) {
+                Button(action: {
+                    showingPrivacyPolicy = true
+                }) {
+                    HStack {
+                        Text("Privacy Policy")
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.gray)
+                            .font(.caption)
+                    }
                 }
-                NavigationLink("Terms of Service") {
-                    Text("Terms of Service Content")
+
+                Button(action: {
+                    showingTerms = true
+                }) {
+                    HStack {
+                        Text("Terms of Service")
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.gray)
+                            .font(.caption)
+                    }
                 }
-                NavigationLink("Help & Support") {
-                    Text("Help Content")
+
+                Button(action: {
+                    showingHelp = true
+                }) {
+                    HStack {
+                        Text("Help & Support")
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .foregroundColor(.gray)
+                            .font(.caption)
+                    }
                 }
             }
             
@@ -106,6 +138,24 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .sheet(isPresented: $showingModelSelector) {
             ModelSelectorView()
+        }
+        .sheet(isPresented: $showingPrivacyPolicy) {
+            WebViewScreen(
+                url: URL(string: "https://polychat.app/privacy")!,
+                title: "Privacy Policy"
+            )
+        }
+        .sheet(isPresented: $showingTerms) {
+            WebViewScreen(
+                url: URL(string: "https://polychat.app/terms")!,
+                title: "Terms of Service"
+            )
+        }
+        .sheet(isPresented: $showingHelp) {
+            WebViewScreen(
+                url: URL(string: "https://nicholasgriffin.dev/contact")!,
+                title: "Help & Support"
+            )
         }
         .onAppear {
             autoTitleGeneration = UserDefaults.standard.bool(forKey: "autoTitleGeneration")

--- a/apps/mobile/ios/Polychat/Views/WebView.swift
+++ b/apps/mobile/ios/Polychat/Views/WebView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+import WebKit
+
+struct WebView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        let webView = WKWebView()
+        webView.navigationDelegate = context.coordinator
+        return webView
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+        var parent: WebView
+
+        init(_ parent: WebView) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            decisionHandler(.allow)
+        }
+    }
+}
+
+struct WebViewScreen: View {
+    let url: URL
+    let title: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            WebView(url: url)
+                .navigationTitle(title)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("Done") {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
- Add WebView component for displaying legal content
- Update Settings with Privacy Policy, Terms of Service, and Help & Support links that open in webviews
- Fix API calls by adding X-Platform header to all requests
- Improve chat input UI with placeholder text, better styling, focus states, and modern send button
- Fix conversation list swipe-to-delete to maintain boxed style instead of rounded