### PR TITLE
Potential fix for code scanning alert no. 35: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,4 +1,6 @@
 name: iOS CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/ai-platform/security/code-scanning/35](https://github.com/nicholasgriffintn/ai-platform/security/code-scanning/35)

To fix this problem, add an explicit `permissions` block that grants only the minimum needed permissions to the workflow. Since the workflow does not interact with the repository except for checking out the code (which only needs read permissions), the recommended fix is to add a `permissions: contents: read` block. This should be added at the top level of the YAML (so it applies to all jobs), just below the workflow `name:` and before the `on:` key, following best practices for workflow security. This change does not affect any functionality since the job only requires read access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
