### PR TITLE
Fix popovers overlapping top navigation

### DIFF
--- a/apps/app/src/components/ui/popover.tsx
+++ b/apps/app/src/components/ui/popover.tsx
@@ -15,6 +15,7 @@ function PopoverContent({
 	className,
 	align = "center",
 	sideOffset = 4,
+	collisionPadding = { top: 64, right: 8, bottom: 8, left: 8 },
 	...props
 }: React.ComponentProps<typeof PopoverPrimitive.Content>) {
 	return (
@@ -23,6 +24,7 @@ function PopoverContent({
 				data-slot="popover-content"
 				align={align}
 				sideOffset={sideOffset}
+				collisionPadding={collisionPadding}
 				className={cn(
 					"bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
 					className,


### PR DESCRIPTION
### Motivation
- Popovers in the app were able to extend into or behind the sticky top navigation, causing UI elements to be obscured. 
- Provide a single, shared fix in the common popover wrapper so all popovers avoid the header area by default.

### Description
- Update `PopoverContent` in `apps/app/src/components/ui/popover.tsx` to accept a `collisionPadding` prop and set a default of `{ top: 64, right: 8, bottom: 8, left: 8 }`. 
- Pass the `collisionPadding` into `PopoverPrimitive.Content` so Radix popovers avoid the top nav while preserving the ability for callers to override the value.

### Testing
- Attempted to run TypeScript checks with `pnpm -C apps/app exec tsc --noEmit --pretty false`, but package manager bootstrap failed in this environment due to registry/network/proxy restrictions so automated type checks could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f79e74fc832aaf40323615bf9778)