### PR TITLE
refactor(api): centralize object guard usage in api modules

### DIFF
--- a/apps/api/src/lib/chat/agent/runAgentLoop.ts
+++ b/apps/api/src/lib/chat/agent/runAgentLoop.ts
@@ -11,6 +11,7 @@ import { handleToolCalls } from "~/lib/chat/tools";
 import type { IRequest, Message, MessageContent } from "~/types";
 import { AssistantError, ErrorType } from "~/utils/errors";
 import { generateId } from "~/utils/id";
+import { isPlainObject } from "~/utils/objects";
 
 const DEFAULT_AGENT_MAX_STEPS = 8;
 const AGENT_MAX_RECOVERY_REPLANS = 2;
@@ -64,9 +65,6 @@ export interface AgentLoopExecutionResult {
 	toolResponses: Message[];
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function isMessageContentArray(value: unknown[]): value is MessageContent[] {
 	return value.every(
@@ -99,7 +97,7 @@ function normaliseAgentContentForProvider(content: AgentMessage["content"]): Mes
 }
 
 function isMessage(value: unknown): value is Message {
-	if (!isRecord(value)) {
+	if (!isPlainObject(value)) {
 		return false;
 	}
 
@@ -146,7 +144,7 @@ function toProviderMessages(messages: AgentMessage[]): Message[] {
 
 		if ("tool_call_arguments" in message) {
 			const toolCallArguments = message.tool_call_arguments;
-			if (typeof toolCallArguments === "string" || isRecord(toolCallArguments)) {
+			if (typeof toolCallArguments === "string" || isPlainObject(toolCallArguments)) {
 				providerMessage.tool_call_arguments = toolCallArguments;
 			}
 		}
@@ -160,19 +158,19 @@ function toProviderMessages(messages: AgentMessage[]): Message[] {
 }
 
 function isModelToolCall(value: unknown): value is ModelToolCall {
-	if (!isRecord(value)) {
+	if (!isPlainObject(value)) {
 		return false;
 	}
 
 	if ("function" in value && value.function !== undefined && value.function !== null) {
-		return isRecord(value.function);
+		return isPlainObject(value.function);
 	}
 
 	return true;
 }
 
 function normaliseModelResponse(value: unknown): ModelResponse {
-	if (!isRecord(value)) {
+	if (!isPlainObject(value)) {
 		throw new AssistantError(
 			"Provider returned an invalid response shape",
 			ErrorType.PROVIDER_ERROR,
@@ -193,8 +191,8 @@ function normaliseModelResponse(value: unknown): ModelResponse {
 		citations,
 		data: value.data,
 		log_id: typeof value.log_id === "string" ? value.log_id : undefined,
-		usage: isRecord(value.usage) ? value.usage : undefined,
-		usageMetadata: isRecord(value.usageMetadata) ? value.usageMetadata : undefined,
+		usage: isPlainObject(value.usage) ? value.usage : undefined,
+		usageMetadata: isPlainObject(value.usageMetadata) ? value.usageMetadata : undefined,
 		status: typeof value.status === "string" ? value.status : undefined,
 		refusal:
 			typeof value.refusal === "string" ? value.refusal : value.refusal === null ? null : undefined,
@@ -213,7 +211,7 @@ function toToolCallInvocations(toolCalls: ModelToolCall[]): ToolCallInvocation[]
 
 function normaliseProviderToolCalls(toolCalls: ToolCallInvocation[]): Record<string, unknown>[] {
 	return toolCalls.map((toolCall) => {
-		if (isRecord(toolCall.raw)) {
+		if (isPlainObject(toolCall.raw)) {
 			return toolCall.raw;
 		}
 

--- a/apps/api/src/routes/webhooks/github-task-execution.ts
+++ b/apps/api/src/routes/webhooks/github-task-execution.ts
@@ -12,6 +12,7 @@ import type { ServiceContext } from "~/lib/context/serviceContext";
 import { executeDynamicApp } from "~/services/dynamic-apps";
 import type { IEnv, IRequest, IUser } from "~/types";
 import { generateId } from "~/utils/id";
+import { isPlainObject } from "~/utils/objects";
 
 interface GitHubConnectionCredentials {
 	appId: string;
@@ -27,9 +28,6 @@ export interface SandboxExecutionResult {
 	responseId?: string;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null && !Array.isArray(value);
-}
 
 function buildRequest(params: { env: IEnv; user: IUser; context: ServiceContext }): IRequest {
 	return {
@@ -78,7 +76,7 @@ export async function executeWebhookSandboxCommand(params: {
 
 		const responseId =
 			typeof execution.response_id === "string" ? execution.response_id : undefined;
-		const resultRecord = isRecord(execution.data?.result) ? execution.data.result : {};
+		const resultRecord = isPlainObject(execution.data?.result) ? execution.data.result : {};
 
 		return {
 			success: typeof resultRecord.success === "boolean" ? resultRecord.success : true,

--- a/apps/api/src/services/functions/api_call.ts
+++ b/apps/api/src/services/functions/api_call.ts
@@ -5,14 +5,13 @@ import type { ApiToolDefinition } from "./types";
 import { getLogger } from "~/utils/logger";
 import { safeParseJson } from "~/utils/json";
 import { isAbortError } from "~/utils/abort";
+import { isPlainObject } from "~/utils/objects";
 
 const logger = getLogger({ prefix: "services/functions/api_call" });
 
 const DEFAULT_TIMEOUT_MS = 15000;
 const MAX_TIMEOUT_MS = 60000;
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-	typeof value === "object" && value !== null && !Array.isArray(value);
 
 const isPrivateHostname = (hostname: string): boolean => {
 	const normalized = hostname.toLowerCase();
@@ -62,7 +61,7 @@ const isPrivateHostname = (hostname: string): boolean => {
 };
 
 const normalizeHeaders = (headers: unknown): Record<string, string> => {
-	if (!isRecord(headers)) {
+	if (!isPlainObject(headers)) {
 		return {};
 	}
 

--- a/apps/api/src/utils/providerErrors.ts
+++ b/apps/api/src/utils/providerErrors.ts
@@ -1,3 +1,5 @@
+import { isPlainObject } from "~/utils/objects";
+
 export interface ProviderErrorBody {
 	raw_status_code?: unknown;
 	code?: unknown;
@@ -6,9 +8,6 @@ export interface ProviderErrorBody {
 	error?: unknown;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === "object" && value !== null;
-}
 
 export function getProviderErrorMessage(
 	responseJson: ProviderErrorBody | null,
@@ -45,7 +44,7 @@ export function isProviderRateLimit(
 }
 
 export function isProviderRateLimitError(error: unknown): boolean {
-	if (!isRecord(error)) {
+	if (!isPlainObject(error)) {
 		return false;
 	}
 
@@ -57,5 +56,5 @@ export function isProviderRateLimitError(error: unknown): boolean {
 		return true;
 	}
 
-	return isRecord(error.error) && isProviderRateLimit(0, error.error);
+	return isPlainObject(error.error) && isProviderRateLimit(0, error.error);
 }


### PR DESCRIPTION
### Motivation
- Reduce duplication of ad-hoc object-guard helpers scattered across the API codebase by using the centralized shared guard utility. 
- Improve consistency of runtime object-shape checks and make future changes to the guard logic happen in one place (`~/utils/objects`).

### Description
- Replaced local `isRecord` implementations with the shared `isPlainObject` from `~/utils/objects` across several API modules. 
- Updated `apps/api/src/lib/chat/agent/runAgentLoop.ts` to import `isPlainObject` and use it for message, tool-call, and provider response validation. 
- Updated `apps/api/src/routes/webhooks/github-task-execution.ts` to use `isPlainObject` when parsing sandbox dynamic-app results and removed the duplicated local guard. 
- Updated `apps/api/src/services/functions/api_call.ts` to use `isPlainObject` for header normalization and removed the local guard declaration. 
- Updated `apps/api/src/utils/providerErrors.ts` to use `isPlainObject` for top-level and nested provider error inspections and removed the local guard. 

### Testing
- Ran `pnpm -C apps/api typecheck`, which failed in this environment because Corepack could not fetch `pnpm` due to network/proxy restrictions (`Proxy response (403) !== 200 when HTTP Tunneling`).
- No other automated test runs completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f8762934832a9bcf4c1e439749dc)