### PR TITLE
fix: hydrate async user settings form

### DIFF
--- a/apps/app/src/components/Profile/UserSettingsForm.test.tsx
+++ b/apps/app/src/components/Profile/UserSettingsForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import type { UserSettings } from "~/types";
@@ -69,5 +69,51 @@ describe("UserSettingsForm", () => {
 
 		expect(screen.getByLabelText("Speech Provider")).toHaveDisplayValue("Cartesia");
 		expect(screen.getByLabelText("Speech Model")).toHaveDisplayValue("Sonic 3");
+	});
+
+	it("hydrates the form when user settings arrive after the first render", () => {
+		const { rerender } = render(
+			<UserSettingsForm isAuthenticated={true} isPro={true} userSettings={null} />,
+		);
+
+		expect(screen.getByLabelText("Nickname")).toHaveValue("");
+
+		rerender(
+			<UserSettingsForm
+				isAuthenticated={true}
+				isPro={true}
+				userSettings={makeUserSettings({
+					nickname: "Updated Nicholas",
+					speech_provider: "cartesia",
+					speech_model: "sonic-3",
+				})}
+			/>,
+		);
+
+		expect(screen.getByLabelText("Nickname")).toHaveValue("Updated Nicholas");
+		expect(screen.getByLabelText("Speech Provider")).toHaveDisplayValue("Cartesia");
+		expect(screen.getByLabelText("Speech Model")).toHaveDisplayValue("Sonic 3");
+	});
+
+	it("does not overwrite local edits when settings load after the user starts typing", () => {
+		const { rerender } = render(
+			<UserSettingsForm isAuthenticated={true} isPro={true} userSettings={null} />,
+		);
+
+		fireEvent.change(screen.getByLabelText("Nickname"), {
+			target: { value: "Local draft" },
+		});
+
+		rerender(
+			<UserSettingsForm
+				isAuthenticated={true}
+				isPro={true}
+				userSettings={makeUserSettings({
+					nickname: "Server nickname",
+				})}
+			/>,
+		);
+
+		expect(screen.getByLabelText("Nickname")).toHaveValue("Local draft");
 	});
 });

--- a/apps/app/src/components/Profile/UserSettingsForm.test.tsx
+++ b/apps/app/src/components/Profile/UserSettingsForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import type { UserSettings } from "~/types";
@@ -115,5 +115,47 @@ describe("UserSettingsForm", () => {
 		);
 
 		expect(screen.getByLabelText("Nickname")).toHaveValue("Local draft");
+	});
+
+	it("keeps saved edits visible until refreshed settings catch up", async () => {
+		mockUpdateUserSettings.mockResolvedValue(true);
+
+		const initialSettings = makeUserSettings({
+			nickname: "Nicholas",
+		});
+		const { rerender } = render(
+			<UserSettingsForm isAuthenticated={true} isPro={true} userSettings={initialSettings} />,
+		);
+
+		fireEvent.change(screen.getByLabelText("Nickname"), {
+			target: { value: "Updated Nicholas" },
+		});
+		fireEvent.click(screen.getByRole("button", { name: "Save Settings" }));
+
+		await waitFor(() => {
+			expect(mockUpdateUserSettings).toHaveBeenCalledWith(
+				expect.objectContaining({
+					nickname: "Updated Nicholas",
+				}),
+			);
+		});
+
+		rerender(
+			<UserSettingsForm isAuthenticated={true} isPro={true} userSettings={initialSettings} />,
+		);
+
+		expect(screen.getByLabelText("Nickname")).toHaveValue("Updated Nicholas");
+
+		rerender(
+			<UserSettingsForm
+				isAuthenticated={true}
+				isPro={true}
+				userSettings={makeUserSettings({
+					nickname: "Updated Nicholas",
+				})}
+			/>,
+		);
+
+		expect(screen.getByLabelText("Nickname")).toHaveValue("Updated Nicholas");
 	});
 });

--- a/apps/app/src/components/Profile/UserSettingsForm.tsx
+++ b/apps/app/src/components/Profile/UserSettingsForm.tsx
@@ -1,4 +1,4 @@
-import { type FormEvent, useState } from "react";
+import { type FormEvent, useEffect, useState } from "react";
 
 import { Button, FormInput, FormSelect, Switch, Textarea } from "~/components/ui";
 import { EventCategory, useTrackEvent } from "~/hooks/use-track-event";
@@ -21,13 +21,7 @@ interface UserSettingsFormProps {
 	isPro?: boolean;
 }
 
-export function UserSettingsForm({
-	userSettings,
-	isAuthenticated,
-	isPro = false,
-}: UserSettingsFormProps) {
-	const { updateUserSettings, isUpdatingUserSettings } = useAuthStatus();
-	const { trackEvent, trackError } = useTrackEvent();
+function buildUserSettingsFormData(userSettings: UserSettings | null) {
 	const transcriptionSettings = resolveTranscriptionSettings(
 		userSettings?.transcription_provider,
 		userSettings?.transcription_model,
@@ -36,7 +30,8 @@ export function UserSettingsForm({
 		userSettings?.speech_provider,
 		userSettings?.speech_model,
 	);
-	const [formData, setFormData] = useState({
+
+	return {
 		nickname: userSettings?.nickname || "",
 		job_role: userSettings?.job_role || "",
 		traits: userSettings?.traits || "",
@@ -61,13 +56,41 @@ export function UserSettingsForm({
 		speech_model: speechSettings.speech_model,
 		search_provider: userSettings?.search_provider || "",
 		sandbox_model: userSettings?.sandbox_model || "",
-	});
+	};
+}
+
+export function UserSettingsForm({
+	userSettings,
+	isAuthenticated,
+	isPro = false,
+}: UserSettingsFormProps) {
+	const { updateUserSettings, isUpdatingUserSettings } = useAuthStatus();
+	const { trackEvent, trackError } = useTrackEvent();
+	const [formData, setFormData] = useState(() => buildUserSettingsFormData(userSettings));
+	const [hasLocalChanges, setHasLocalChanges] = useState(false);
 	const [saveSuccess, setSaveSuccess] = useState(false);
 	const [saveError, setSaveError] = useState("");
 
+	useEffect(() => {
+		if (hasLocalChanges) {
+			return;
+		}
+
+		setFormData(buildUserSettingsFormData(userSettings));
+	}, [hasLocalChanges, userSettings]);
+
+	const updateFormData = (
+		updater: typeof formData | ((previous: typeof formData) => typeof formData),
+	) => {
+		setHasLocalChanges(true);
+		setSaveSuccess(false);
+		setSaveError("");
+		setFormData((previous) => (typeof updater === "function" ? updater(previous) : updater));
+	};
+
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
 		const { name, value } = e.target;
-		setFormData((prev) => ({
+		updateFormData((prev) => ({
 			...prev,
 			[name]: value,
 		}));
@@ -86,7 +109,7 @@ export function UserSettingsForm({
 		const newProvider = e.target.value as TranscriptionProviderId;
 		const [firstModelForProvider] = getTranscriptionModelOptions(newProvider);
 
-		setFormData((prev) => ({
+		updateFormData((prev) => ({
 			...prev,
 			transcription_provider: newProvider,
 			transcription_model: firstModelForProvider.id,
@@ -106,7 +129,7 @@ export function UserSettingsForm({
 		const newProvider = e.target.value as SpeechProviderId;
 		const [firstModelForProvider] = getSpeechModelOptions(newProvider);
 
-		setFormData((prev) => ({
+		updateFormData((prev) => ({
 			...prev,
 			speech_provider: newProvider,
 			speech_model: firstModelForProvider.id,
@@ -168,6 +191,7 @@ export function UserSettingsForm({
 					};
 
 			await updateUserSettings(settingsPayload);
+			setHasLocalChanges(false);
 			setSaveSuccess(true);
 
 			trackEvent({
@@ -294,10 +318,10 @@ export function UserSettingsForm({
 						name="sandbox_model"
 						value={formData.sandbox_model}
 						onChange={(e) => {
-							setFormData({
-								...formData,
+							updateFormData((prev) => ({
+								...prev,
 								sandbox_model: e.target.value,
-							});
+							}));
 
 							trackEvent({
 								name: "sandbox_model_changed",
@@ -327,7 +351,7 @@ export function UserSettingsForm({
 						id="guardrails_enabled"
 						checked={formData.guardrails_enabled}
 						onChange={(e) =>
-							setFormData((prev) => ({
+							updateFormData((prev) => ({
 								...prev,
 								guardrails_enabled: e.target.checked,
 							}))
@@ -346,10 +370,10 @@ export function UserSettingsForm({
 						name="guardrails_provider"
 						value={formData.guardrails_provider}
 						onChange={(e) =>
-							setFormData({
-								...formData,
+							updateFormData((prev) => ({
+								...prev,
 								guardrails_provider: e.target.value,
-							})
+							}))
 						}
 					>
 						<option value="llamaguard">LlamaGuard</option>
@@ -417,10 +441,10 @@ export function UserSettingsForm({
 						name="embedding_provider"
 						value={formData.embedding_provider}
 						onChange={(e) =>
-							setFormData({
-								...formData,
+							updateFormData((prev) => ({
+								...prev,
 								embedding_provider: e.target.value,
-							})
+							}))
 						}
 					>
 						<option value="vectorize">Vectorize</option>
@@ -516,10 +540,10 @@ export function UserSettingsForm({
 								name="s3vectors_region"
 								value={formData.s3vectors_region}
 								onChange={(e) =>
-									setFormData({
-										...formData,
+									updateFormData((prev) => ({
+										...prev,
 										s3vectors_region: e.target.value,
-									})
+									}))
 								}
 							>
 								<option value="us-east-1">US East (N. Virginia)</option>
@@ -553,7 +577,7 @@ export function UserSettingsForm({
 						id="memories_save_enabled"
 						checked={formData.memories_save_enabled}
 						onChange={(e) =>
-							setFormData((prev) => ({
+							updateFormData((prev) => ({
 								...prev,
 								memories_save_enabled: e.target.checked,
 							}))
@@ -575,7 +599,7 @@ export function UserSettingsForm({
 						id="memories_chat_history_enabled"
 						checked={formData.memories_chat_history_enabled}
 						onChange={(e) =>
-							setFormData((prev) => ({
+							updateFormData((prev) => ({
 								...prev,
 								memories_chat_history_enabled: e.target.checked,
 							}))
@@ -605,7 +629,7 @@ export function UserSettingsForm({
 						id="tracking_enabled"
 						checked={formData.tracking_enabled}
 						onChange={(e) =>
-							setFormData((prev) => ({
+							updateFormData((prev) => ({
 								...prev,
 								tracking_enabled: e.target.checked,
 							}))
@@ -662,10 +686,10 @@ export function UserSettingsForm({
 						name="transcription_model"
 						value={formData.transcription_model}
 						onChange={(e) =>
-							setFormData({
-								...formData,
+							updateFormData((prev) => ({
+								...prev,
 								transcription_model: e.target.value,
-							})
+							}))
 						}
 					>
 						{getTranscriptionModelOptions(formData.transcription_provider).map((model) => (
@@ -715,10 +739,10 @@ export function UserSettingsForm({
 						name="speech_model"
 						value={formData.speech_model}
 						onChange={(e) =>
-							setFormData({
-								...formData,
+							updateFormData((prev) => ({
+								...prev,
 								speech_model: e.target.value,
-							})
+							}))
 						}
 					>
 						{getSpeechModelOptions(formData.speech_provider).map((model) => (
@@ -750,10 +774,10 @@ export function UserSettingsForm({
 						name="search_provider"
 						value={formData.search_provider}
 						onChange={(e) => {
-							setFormData({
-								...formData,
+							updateFormData((prev) => ({
+								...prev,
 								search_provider: e.target.value,
-							});
+							}));
 
 							trackEvent({
 								name: "search_provider_changed",

--- a/apps/app/src/components/Profile/UserSettingsForm.tsx
+++ b/apps/app/src/components/Profile/UserSettingsForm.tsx
@@ -59,6 +59,15 @@ function buildUserSettingsFormData(userSettings: UserSettings | null) {
 	};
 }
 
+function areUserSettingsFormDataEqual(
+	left: ReturnType<typeof buildUserSettingsFormData>,
+	right: ReturnType<typeof buildUserSettingsFormData>,
+) {
+	return Object.keys(left).every(
+		(key) => left[key as keyof typeof left] === right[key as keyof typeof right],
+	);
+}
+
 export function UserSettingsForm({
 	userSettings,
 	isAuthenticated,
@@ -68,21 +77,37 @@ export function UserSettingsForm({
 	const { trackEvent, trackError } = useTrackEvent();
 	const [formData, setFormData] = useState(() => buildUserSettingsFormData(userSettings));
 	const [hasLocalChanges, setHasLocalChanges] = useState(false);
+	const [pendingSavedFormData, setPendingSavedFormData] = useState<ReturnType<
+		typeof buildUserSettingsFormData
+	> | null>(null);
 	const [saveSuccess, setSaveSuccess] = useState(false);
 	const [saveError, setSaveError] = useState("");
 
 	useEffect(() => {
+		const nextFormData = buildUserSettingsFormData(userSettings);
+		if (pendingSavedFormData) {
+			if (!areUserSettingsFormDataEqual(nextFormData, pendingSavedFormData)) {
+				return;
+			}
+
+			setFormData(nextFormData);
+			setHasLocalChanges(false);
+			setPendingSavedFormData(null);
+			return;
+		}
+
 		if (hasLocalChanges) {
 			return;
 		}
 
-		setFormData(buildUserSettingsFormData(userSettings));
-	}, [hasLocalChanges, userSettings]);
+		setFormData(nextFormData);
+	}, [hasLocalChanges, pendingSavedFormData, userSettings]);
 
 	const updateFormData = (
 		updater: typeof formData | ((previous: typeof formData) => typeof formData),
 	) => {
 		setHasLocalChanges(true);
+		setPendingSavedFormData(null);
 		setSaveSuccess(false);
 		setSaveError("");
 		setFormData((previous) => (typeof updater === "function" ? updater(previous) : updater));
@@ -191,7 +216,7 @@ export function UserSettingsForm({
 					};
 
 			await updateUserSettings(settingsPayload);
-			setHasLocalChanges(false);
+			setPendingSavedFormData(formData);
 			setSaveSuccess(true);
 
 			trackEvent({

--- a/apps/app/src/hooks/__test__/useAuth.test.tsx
+++ b/apps/app/src/hooks/__test__/useAuth.test.tsx
@@ -1,0 +1,122 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { authService } from "~/lib/api/auth-service";
+import { useAuthStatus } from "../useAuth";
+
+const setHasApiKey = vi.fn();
+const setIsAuthenticated = vi.fn();
+const setIsAuthenticationLoading = vi.fn();
+const setIsPro = vi.fn();
+
+const setUsageLimits = vi.fn();
+
+vi.mock("~/state/stores/chatStore", () => ({
+	useChatStore: () => ({
+		setHasApiKey,
+		setIsAuthenticated,
+		setIsAuthenticationLoading,
+		setIsPro,
+	}),
+}));
+
+vi.mock("~/state/stores/usageStore", () => ({
+	useUsageStore: {
+		getState: () => ({
+			setUsageLimits,
+		}),
+	},
+}));
+
+describe("useAuthStatus", () => {
+	let currentUserSettings: { id: string; nickname: string } | null;
+
+	const createWrapper = () => {
+		const queryClient = new QueryClient({
+			defaultOptions: {
+				queries: {
+					retry: false,
+				},
+			},
+		});
+
+		return ({ children }: { children: ReactNode }) => (
+			<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+		);
+	};
+
+	beforeEach(() => {
+		vi.restoreAllMocks();
+		setHasApiKey.mockReset();
+		setIsAuthenticated.mockReset();
+		setIsAuthenticationLoading.mockReset();
+		setIsPro.mockReset();
+		setUsageLimits.mockReset();
+
+		currentUserSettings = {
+			id: "settings-1",
+			nickname: "Nicholas",
+		};
+
+		vi.spyOn(authService, "checkAuthStatus").mockResolvedValue(true);
+		vi.spyOn(authService, "getToken").mockResolvedValue("token");
+		vi.spyOn(authService, "getUser").mockReturnValue({
+			id: 1,
+			plan_id: "free",
+		} as any);
+		vi.spyOn(authService, "getUserSettings").mockImplementation(() => currentUserSettings as any);
+	});
+
+	it("returns an async settings updater and eventually refreshes user settings", async () => {
+		vi.spyOn(authService, "updateUserSettings").mockImplementation(async (settings) => {
+			currentUserSettings = {
+				...(currentUserSettings as { id: string; nickname: string }),
+				...settings,
+			} as { id: string; nickname: string };
+			return true;
+		});
+
+		const { result } = renderHook(() => useAuthStatus(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.userSettings?.nickname).toBe("Nicholas");
+		});
+
+		let savePromise: Promise<boolean>;
+		await act(async () => {
+			savePromise = result.current.updateUserSettings({
+				nickname: "Updated Nicholas",
+			});
+			expect(savePromise).toBeInstanceOf(Promise);
+			await expect(savePromise).resolves.toBe(true);
+		});
+
+		await waitFor(() => {
+			expect(result.current.userSettings?.nickname).toBe("Updated Nicholas");
+		});
+	});
+
+	it("rejects the async settings updater when the save fails", async () => {
+		vi.spyOn(authService, "updateUserSettings").mockResolvedValue(false);
+
+		const { result } = renderHook(() => useAuthStatus(), {
+			wrapper: createWrapper(),
+		});
+
+		await waitFor(() => {
+			expect(result.current.isAuthenticated).toBe(true);
+		});
+
+		await act(async () => {
+			await expect(
+				result.current.updateUserSettings({
+					nickname: "Updated Nicholas",
+				}),
+			).rejects.toThrow("Failed to update user settings");
+		});
+	});
+});

--- a/apps/app/src/hooks/useAuth.ts
+++ b/apps/app/src/hooks/useAuth.ts
@@ -3,6 +3,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { authService } from "~/lib/api/auth-service";
 import { useChatStore } from "~/state/stores/chatStore";
 import { useUsageStore } from "~/state/stores/usageStore";
+import type { UserSettings } from "~/types";
 
 export const AUTH_QUERY_KEYS = {
 	authStatus: ["auth", "status"],
@@ -76,11 +77,17 @@ export function useAuthStatus() {
 	});
 
 	const updateUserSettingsMutation = useMutation({
-		mutationFn: async (settings: Partial<any>) => {
-			return await authService.updateUserSettings(settings);
+		mutationFn: async (settings: Partial<UserSettings>) => {
+			const didUpdate = await authService.updateUserSettings(settings);
+			if (!didUpdate) {
+				throw new Error("Failed to update user settings");
+			}
+
+			return true;
 		},
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEYS.userSettings });
+		onSuccess: async () => {
+			queryClient.setQueryData(AUTH_QUERY_KEYS.userSettings, authService.getUserSettings());
+			await queryClient.invalidateQueries({ queryKey: AUTH_QUERY_KEYS.userSettings });
 		},
 	});
 
@@ -92,7 +99,7 @@ export function useAuthStatus() {
 		loginWithGithub,
 		logout: logoutMutation.mutate,
 		isLoggingOut: logoutMutation.isPending,
-		updateUserSettings: updateUserSettingsMutation.mutate,
+		updateUserSettings: updateUserSettingsMutation.mutateAsync,
 		isUpdatingUserSettings: updateUserSettingsMutation.isPending,
 	};
 }


### PR DESCRIPTION
Fixes profile customisation form hydration when settings load after the page mounts.

The customisation tab can render before `userSettings` returns from the auth/API layer. `UserSettingsForm` only initialised its local state on first render, so saved nickname, speech, transcription, and other preferences could stay on blank/default values until the user manually refreshed the page. That makes recent BYOK and audio-setting changes look unsaved even when the API already has the right values.

- derive form state from a shared `buildUserSettingsFormData()` helper instead of duplicating the initialiser
- hydrate the local form when `userSettings` changes while the form is still pristine
- stop that hydration from overwriting in-progress edits after the user has started typing
- clear stale save feedback on new edits and reset the pristine state after a successful save
- add regression coverage for async settings hydration and the local-edit protection path

Tests:
- `pnpm --filter @assistant/app typecheck`
- `pnpm --filter @assistant/app check`
- `pnpm --filter @assistant/app test -- src/components/Profile/UserSettingsForm.test.tsx`
