### PR TITLE
fix: gate realtime sessions by model access

### DIFF
--- a/apps/api/src/routes/__test__/realtime.test.ts
+++ b/apps/api/src/routes/__test__/realtime.test.ts
@@ -1,0 +1,124 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import realtimeRoutes from "../realtime";
+import type { IUser } from "~/types";
+
+const createSessionMock = vi.hoisted(() => vi.fn());
+const createMistralRealtimeProxyResponseMock = vi.hoisted(() => vi.fn());
+const getDefaultModelMock = vi.hoisted(() => vi.fn());
+const listModelsMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/lib/providers/capabilities/realtime", () => ({
+	getRealtimeProvider: vi.fn(() => ({
+		createSession: createSessionMock,
+		getDefaultModel: getDefaultModelMock,
+	})),
+	listRealtimeProviders: vi.fn(() => ["openai"]),
+	parseRealtimeModalities: vi.fn(() => undefined),
+	parseRealtimeTransport: vi.fn(() => undefined),
+}));
+
+vi.mock("~/services/models", () => ({
+	listModels: listModelsMock,
+}));
+
+vi.mock("~/services/realtime/mistral", () => ({
+	createMistralRealtimeProxyResponse: createMistralRealtimeProxyResponseMock,
+}));
+
+const testUser = {
+	id: 42,
+	name: "Test User",
+	avatar_url: null,
+	email: "test@example.com",
+	github_username: null,
+	company: null,
+	site: null,
+	location: null,
+	bio: null,
+	twitter_username: null,
+	created_at: "2026-06-02T00:00:00.000Z",
+	updated_at: "2026-06-02T00:00:00.000Z",
+	setup_at: null,
+	terms_accepted_at: null,
+	plan_id: "free",
+} satisfies IUser;
+
+function createApp(user: IUser = testUser) {
+	const app = new Hono();
+
+	app.use("/realtime/*", async (c, next) => {
+		(c as any).set("user", user);
+		await next();
+	});
+
+	app.route("/realtime", realtimeRoutes);
+
+	return app;
+}
+
+describe("realtime routes", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getDefaultModelMock.mockReturnValue("gpt-realtime-2");
+	});
+
+	it("blocks session creation when the user cannot access the realtime model", async () => {
+		listModelsMock.mockResolvedValue({
+			"deepseek-chat": {
+				matchingModel: "deepseek-chat",
+				name: "DeepSeek Chat",
+				provider: "deepseek",
+			},
+		});
+
+		const response = await createApp().request(
+			new Request("https://api.polychat.test/realtime/session/realtime?provider=openai", {
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(403);
+		await expect(response.json()).resolves.toEqual({
+			status: "error",
+			message: "Model not found or user does not have access",
+		});
+		expect(createSessionMock).not.toHaveBeenCalled();
+	});
+
+	it("allows session creation when the default realtime model is accessible", async () => {
+		listModelsMock.mockResolvedValue({
+			"gpt-realtime-2": {
+				matchingModel: "gpt-realtime-2",
+				name: "GPT Realtime 2",
+				provider: "openai",
+			},
+		});
+		createSessionMock.mockResolvedValue({
+			id: "session_123",
+			provider: "openai",
+			transport: "webrtc",
+		});
+
+		const response = await createApp().request(
+			new Request("https://api.polychat.test/realtime/session/realtime?provider=openai", {
+				method: "POST",
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toEqual({
+			id: "session_123",
+			provider: "openai",
+			transport: "webrtc",
+		});
+		expect(createSessionMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				model: undefined,
+				type: "realtime",
+				user: testUser,
+			}),
+		);
+	});
+});

--- a/apps/api/src/routes/realtime.ts
+++ b/apps/api/src/routes/realtime.ts
@@ -12,6 +12,7 @@ import {
 	parseRealtimeTransport,
 	type RealtimeTranscriptionDelay,
 } from "~/lib/providers/capabilities/realtime";
+import { userCanAccessRealtimeModel } from "~/services/realtime/access";
 import { createMistralRealtimeProxyResponse } from "~/services/realtime/mistral";
 
 const app = new Hono();
@@ -67,6 +68,29 @@ addRoute(app, "post", "/session/:type", {
 			const provider = getRealtimeProvider(providerName, { env, user });
 			if (model && provider.models && !provider.models.includes(model)) {
 				return ResponseFactory.error(c, "Invalid model specified", 400);
+			}
+
+			let requestedModel = model;
+			if (!requestedModel) {
+				try {
+					requestedModel = provider.getDefaultModel(type);
+				} catch (error) {
+					return ResponseFactory.error(
+						c,
+						error instanceof Error ? error.message : "Invalid session type",
+						400,
+					);
+				}
+			}
+
+			if (
+				!(await userCanAccessRealtimeModel({
+					env,
+					userId: user.id,
+					model: requestedModel,
+				}))
+			) {
+				return ResponseFactory.error(c, "Model not found or user does not have access", 403);
 			}
 
 			const transport = parseRealtimeTransport(transportQuery);

--- a/apps/api/src/services/realtime/access.ts
+++ b/apps/api/src/services/realtime/access.ts
@@ -1,0 +1,33 @@
+import { listModels } from "~/services/models";
+import type { IEnv } from "~/types";
+
+function matchesRequestedModel(
+	requestedModel: string,
+	modelId: string,
+	model: {
+		matchingModel?: string;
+		name?: string;
+	},
+): boolean {
+	return (
+		modelId === requestedModel ||
+		model.matchingModel === requestedModel ||
+		model.name === requestedModel
+	);
+}
+
+export async function userCanAccessRealtimeModel({
+	env,
+	userId,
+	model,
+}: {
+	env: IEnv;
+	userId: number;
+	model: string;
+}): Promise<boolean> {
+	const accessibleModels = await listModels(env, userId);
+
+	return Object.entries(accessibleModels).some(([modelId, config]) =>
+		matchesRequestedModel(model, modelId, config),
+	);
+}


### PR DESCRIPTION
This gates realtime session creation on the same model-access rules used elsewhere in the app/API.

Signed-in users could hit `POST /realtime/session/:type` and mint live provider sessions for hard-coded realtime defaults even when those models were not in their accessible model set. The affected flow is the assistant app live mode selecting OpenAI/Gemini/Mistral realtime defaults and the API route only checking `user?.id` before creating provider sessions. Wider impact: users could consume server-side realtime provider access that their account was not authorised to use, and the UI/API access model diverged for live sessions.

- Resolve the effective realtime model before session creation, including provider defaults when the client omits `model`.
- Reject session creation with `403` when the requested/default realtime model is not accessible to the signed-in user.
- Keep the route thin by isolating the access check in a small realtime service helper.
- Add route regression coverage for both the blocked and allowed cases.

Recommendation: keep frontend live-mode availability aligned with the backend model gate so ineligible users do not discover the restriction only after attempting session creation.

Tests: `pnpm --filter @assistant/schemas build`, `pnpm --dir apps/api exec vitest run src/routes/__test__/realtime.test.ts src/services/realtime/__test__/mistral.test.ts`, and `pnpm --dir apps/api typecheck`.