### PR TITLE
fix: align dynamic app execute contract

### DIFF
--- a/apps/api/src/routes/dynamic-apps.ts
+++ b/apps/api/src/routes/dynamic-apps.ts
@@ -28,6 +28,26 @@ import { generateId } from "~/utils/id";
 import { getServiceContext } from "~/lib/context/serviceContext";
 
 const logger = getLogger({ prefix: "routes/dynamic-apps" });
+const dynamicAppErrorResponseSchema = z.object({
+	error: z.string(),
+	message: z.string().optional(),
+});
+const dynamicAppExecutionUnauthorizedResponseSchema = z.object({
+	response: z.object({
+		status: z.literal("error"),
+		message: z.string(),
+	}),
+});
+const dynamicAppExecutionResponseSchema = z.object({
+	success: z.boolean(),
+	response_id: z.string().optional(),
+	data: z.object({
+		message: z.string(),
+		timestamp: z.iso.datetime(),
+		input: z.record(z.string(), z.unknown()),
+		result: z.unknown(),
+	}),
+});
 
 const dynamicApps = new Hono();
 
@@ -91,12 +111,12 @@ addRoute(dynamicApps, "get", "/:id", {
 	description: "Returns the complete schema for a specific dynamic app",
 	responses: {
 		200: { description: "Dynamic app schema", schema: dynamicAppSchema },
-		400: { description: "Bad request", schema: errorResponseSchema },
+		400: { description: "Bad request", schema: dynamicAppErrorResponseSchema },
 		401: {
 			description: "Authentication required",
 			schema: errorResponseSchema,
 		},
-		404: { description: "App not found", schema: errorResponseSchema },
+		404: { description: "App not found", schema: dynamicAppErrorResponseSchema },
 	},
 	handler: async ({ raw }) =>
 		(async (c: Context) => {
@@ -122,14 +142,17 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 	summary: "Execute dynamic app",
 	description: "Executes a dynamic app with the provided form data",
 	responses: {
-		200: { description: "App execution result", schema: z.string() },
-		400: { description: "Invalid form data", schema: errorResponseSchema },
+		200: {
+			description: "App execution result",
+			schema: dynamicAppExecutionResponseSchema,
+		},
+		400: { description: "Invalid form data", schema: dynamicAppErrorResponseSchema },
 		401: {
 			description: "Authentication required",
-			schema: errorResponseSchema,
+			schema: dynamicAppExecutionUnauthorizedResponseSchema,
 		},
-		404: { description: "App not found", schema: errorResponseSchema },
-		500: { description: "Server error", schema: errorResponseSchema },
+		404: { description: "App not found", schema: dynamicAppErrorResponseSchema },
+		500: { description: "Server error", schema: dynamicAppErrorResponseSchema },
 	},
 	handler: async ({ raw }) =>
 		(async (c: Context) => {
@@ -203,12 +226,12 @@ addRoute(dynamicApps, "get", "/responses/:responseId", {
 			description: "Stored dynamic-app response",
 			schema: z.object({ response: z.any() }),
 		},
-		400: { description: "Bad request", schema: errorResponseSchema },
+		400: { description: "Bad request", schema: dynamicAppErrorResponseSchema },
 		401: {
 			description: "Authentication required",
 			schema: errorResponseSchema,
 		},
-		404: { description: "Response not found", schema: errorResponseSchema },
+		404: { description: "Response not found", schema: dynamicAppErrorResponseSchema },
 	},
 	handler: async ({ raw }) =>
 		(async (c: Context) => {

--- a/apps/app/src/lib/api/dynamic-apps.test.ts
+++ b/apps/app/src/lib/api/dynamic-apps.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { executeDynamicApp } from "./dynamic-apps";
+
+describe("dynamic-apps api", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("preserves dynamic app execution metadata", async () => {
+		const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+			Response.json({
+				success: true,
+				response_id: "response-123",
+				data: {
+					message: "Successfully executed Research app",
+					timestamp: "2026-06-02T09:00:00.000Z",
+					input: { query: "contract drift" },
+					result: { summary: "ok" },
+				},
+			}),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await executeDynamicApp("research", { query: "contract drift" });
+
+		expect(result).toEqual({
+			success: true,
+			response_id: "response-123",
+			data: {
+				message: "Successfully executed Research app",
+				timestamp: "2026-06-02T09:00:00.000Z",
+				input: { query: "contract drift" },
+				result: { summary: "ok" },
+			},
+		});
+	});
+});

--- a/apps/app/src/lib/api/dynamic-apps.ts
+++ b/apps/app/src/lib/api/dynamic-apps.ts
@@ -25,6 +25,17 @@ import type {
 import { apiService } from "./api-service";
 import { fetchApi, returnFetchedData } from "./fetch-wrapper";
 
+export interface DynamicAppExecutionResult {
+	success: boolean;
+	response_id?: string;
+	data: {
+		message: string;
+		timestamp: string;
+		input: Record<string, unknown>;
+		result: unknown;
+	};
+}
+
 export const fetchDynamicApps = async (): Promise<DynamicAppsResponse> => {
 	try {
 		let headers = {};
@@ -134,7 +145,7 @@ export const fetchDynamicAppResponses = async (appId?: string): Promise<AppDataI
 export const executeDynamicApp = async (
 	id: string,
 	formData: Record<string, any>,
-): Promise<Record<string, any>> => {
+): Promise<DynamicAppExecutionResult> => {
 	try {
 		let headers = {};
 		try {
@@ -153,8 +164,7 @@ export const executeDynamicApp = async (
 			throw new Error(`Failed to execute dynamic app: ${response.statusText}`);
 		}
 
-		const data = await returnFetchedData<Record<string, any>>(response);
-		return data;
+		return (await response.json()) as DynamicAppExecutionResult;
 	} catch (error) {
 		console.error(`Error executing dynamic app ${id}:`, error);
 		throw error;


### PR DESCRIPTION
This aligns the dynamic-app execute contract between the app and API.

The API execute route returns a top-level object with `success`, `response_id`, and `data`, but the app-side generic response unwrapping was stripping the top-level fields whenever `data` existed. That broke the saved-response redirect and dropped execute metadata from the result surface. The route metadata also advertised a `string` response that did not match the real runtime shape.

- preserve the full execute payload in the app API client so `response_id` survives for `/apps/responses/:id` navigation
- add a focused frontend regression test for execute-response metadata preservation
- align the API route response schemas with the actual success and error payloads returned by the execute flow

User-facing seam:
```ts
const result = await executeApp({ id: selectedAppId, formData });
if (result?.response_id) {
	navigate(`/apps/responses/${result.response_id}`);
}
```

This flow is shared by dynamic apps generally, so the wider impact is any app execution that persists a response and expects the frontend to use `response_id` rather than only the nested `data` payload. Recommendation: keep execute-path clients off the generic `returnFetchedData()` unwrapping when the contract intentionally uses top-level metadata.

Tests and validation:
- `vitest run apps/app/src/lib/api/dynamic-apps.test.ts`
- `tsc -p apps/app/tsconfig.json --noEmit`
- `tsup` in `packages/schemas`
- `tsc -p apps/api/tsconfig.json --noEmit`