### PR TITLE
refactor: share message token estimation

### DIFF
--- a/apps/api/src/lib/formatter/__test__/messages.test.ts
+++ b/apps/api/src/lib/formatter/__test__/messages.test.ts
@@ -141,6 +141,54 @@ describe("MessageFormatter", () => {
 			expect(result[1].role).toBe("assistant");
 		});
 
+		it("should truncate by token budget for tail strategy", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "x".repeat(1200) },
+				{ role: "user", content: "y".repeat(1200) },
+				{ role: "user", content: "z".repeat(1200) },
+			];
+
+			const result = MessageFormatter.formatMessages(messages, {
+				maxTokens: 500,
+				truncationStrategy: "tail",
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: "user", content: "z".repeat(1200) });
+		});
+
+		it("should truncate by token budget for head strategy", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "x".repeat(1200) },
+				{ role: "user", content: "y".repeat(1200) },
+				{ role: "user", content: "z".repeat(1200) },
+			];
+
+			const result = MessageFormatter.formatMessages(messages, {
+				maxTokens: 500,
+				truncationStrategy: "head",
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: "user", content: "x".repeat(1200) });
+		});
+
+		it("should truncate by token budget for middle strategy", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "x".repeat(1200) },
+				{ role: "user", content: "y".repeat(1200) },
+				{ role: "user", content: "z".repeat(1200) },
+			];
+
+			const result = MessageFormatter.formatMessages(messages, {
+				maxTokens: 500,
+				truncationStrategy: "middle",
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: "user", content: "y".repeat(1200) });
+		});
+
 		it("should format tool messages for anthropic provider", () => {
 			const messages: Message[] = [
 				{

--- a/apps/api/src/lib/formatter/messages.ts
+++ b/apps/api/src/lib/formatter/messages.ts
@@ -299,7 +299,7 @@ export class MessageFormatter {
 
 						formattedMessages.push(newMessage);
 					}
-		}
+			}
 		}
 		return formattedMessages;
 	}
@@ -341,34 +341,34 @@ export class MessageFormatter {
 					.map((item) => MessageFormatter.formatBedrockContent(item))
 					.filter((item) => item !== null);
 			case "workers-ai":
-				case "ollama":
-				case "github-models": {
-					const imageItem = content.find(
-						(item) => typeof item === "object" && "type" in item && item.type === "image_url",
-					);
+			case "ollama":
+			case "github-models": {
+				const imageItem = content.find(
+					(item) => typeof item === "object" && "type" in item && item.type === "image_url",
+				);
 
-					if (
-						imageItem &&
-						typeof imageItem === "object" &&
-						"image_url" in imageItem &&
-						imageItem.image_url &&
-						typeof imageItem.image_url === "object" &&
-						"url" in imageItem.image_url
-					) {
-						return {
-							text: content
-								.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-								.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-								.join("\n"),
-							image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
-						};
-					}
-
-					return content
-						.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-						.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-						.join("\n");
+				if (
+					imageItem &&
+					typeof imageItem === "object" &&
+					"image_url" in imageItem &&
+					imageItem.image_url &&
+					typeof imageItem.image_url === "object" &&
+					"url" in imageItem.image_url
+				) {
+					return {
+						text: content
+							.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+							.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+							.join("\n"),
+						image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
+					};
 				}
+
+				return content
+					.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+					.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+					.join("\n");
+			}
 			default:
 				return content.filter(
 					(item) => typeof item === "object" && "type" in item && item.type !== "markdown_document",
@@ -441,10 +441,7 @@ export class MessageFormatter {
 		}
 	}
 
-	private static takeMessagesUntilTokenBudget(
-		messages: Message[],
-		maxTokens: number,
-	): Message[] {
+	private static takeMessagesUntilTokenBudget(messages: Message[], maxTokens: number): Message[] {
 		const keptMessages: Message[] = [];
 		let usedTokens = 0;
 
@@ -517,9 +514,7 @@ export class MessageFormatter {
 			}
 		}
 
-		return [...selectedIndices]
-			.sort((left, right) => left - right)
-			.map((index) => messages[index]);
+		return [...selectedIndices].sort((left, right) => left - right).map((index) => messages[index]);
 	}
 
 	private static appendUniqueInstructionPart(
@@ -611,9 +606,9 @@ export class MessageFormatter {
 					? toolCall.id
 					: undefined;
 
-			if (!name || !callId) {
-				return null;
-			}
+		if (!name || !callId) {
+			return null;
+		}
 
 		return {
 			type: "function_call",

--- a/apps/api/src/lib/formatter/messages.ts
+++ b/apps/api/src/lib/formatter/messages.ts
@@ -2,6 +2,7 @@ import type { ContentType, Message, MessageContent } from "~/types";
 import { safeParseJson } from "~/utils/json";
 import { isRecord } from "~/utils/objects";
 import { hasToolCalls } from "~/utils/toolCalls";
+import { estimateMessageTokens } from "~/lib/messageTokens";
 
 type OpenAIResponsesInputItem = Record<string, unknown>;
 
@@ -298,7 +299,7 @@ export class MessageFormatter {
 
 						formattedMessages.push(newMessage);
 					}
-			}
+		}
 		}
 		return formattedMessages;
 	}
@@ -340,34 +341,34 @@ export class MessageFormatter {
 					.map((item) => MessageFormatter.formatBedrockContent(item))
 					.filter((item) => item !== null);
 			case "workers-ai":
-			case "ollama":
-			case "github-models": {
-				const imageItem = content.find(
-					(item) => typeof item === "object" && "type" in item && item.type === "image_url",
-				);
+				case "ollama":
+				case "github-models": {
+					const imageItem = content.find(
+						(item) => typeof item === "object" && "type" in item && item.type === "image_url",
+					);
 
-				if (
-					imageItem &&
-					typeof imageItem === "object" &&
-					"image_url" in imageItem &&
-					imageItem.image_url &&
-					typeof imageItem.image_url === "object" &&
-					"url" in imageItem.image_url
-				) {
-					return {
-						text: content
-							.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-							.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-							.join("\n"),
-						image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
-					};
+					if (
+						imageItem &&
+						typeof imageItem === "object" &&
+						"image_url" in imageItem &&
+						imageItem.image_url &&
+						typeof imageItem.image_url === "object" &&
+						"url" in imageItem.image_url
+					) {
+						return {
+							text: content
+								.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+								.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+								.join("\n"),
+							image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
+						};
+					}
+
+					return content
+						.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+						.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+						.join("\n");
 				}
-
-				return content
-					.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-					.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-					.join("\n");
-			}
 			default:
 				return content.filter(
 					(item) => typeof item === "object" && "type" in item && item.type !== "markdown_document",
@@ -418,12 +419,7 @@ export class MessageFormatter {
 	}
 
 	private static countTokens(messages: Message[]): number {
-		return messages.reduce(
-			(total, msg) =>
-				total +
-				(typeof msg.content === "string" ? msg.content.length : JSON.stringify(msg.content).length),
-			0,
-		);
+		return messages.reduce((total, message) => total + estimateMessageTokens(message), 0);
 	}
 
 	private static truncateMessages(
@@ -433,17 +429,97 @@ export class MessageFormatter {
 	): Message[] {
 		switch (strategy) {
 			case "tail":
-				return messages.slice(-Math.floor(messages.length / 2));
+				return MessageFormatter.takeMessagesUntilTokenBudget(
+					[...messages].reverse(),
+					maxTokens,
+				).reverse();
 			case "head":
-				return messages.slice(0, Math.floor(messages.length / 2));
+				return MessageFormatter.takeMessagesUntilTokenBudget(messages, maxTokens);
 			case "middle": {
-				const midPoint = Math.floor(messages.length / 2);
-				return messages.slice(
-					midPoint - Math.floor(maxTokens / 2),
-					midPoint + Math.floor(maxTokens / 2),
-				);
+				return MessageFormatter.takeMessagesAroundMiddle(messages, maxTokens);
 			}
 		}
+	}
+
+	private static takeMessagesUntilTokenBudget(
+		messages: Message[],
+		maxTokens: number,
+	): Message[] {
+		const keptMessages: Message[] = [];
+		let usedTokens = 0;
+
+		for (const message of messages) {
+			const messageTokens = estimateMessageTokens(message);
+
+			if (keptMessages.length === 0 && messageTokens > maxTokens) {
+				return [message];
+			}
+
+			if (usedTokens + messageTokens > maxTokens) {
+				break;
+			}
+
+			keptMessages.push(message);
+			usedTokens += messageTokens;
+		}
+
+		return keptMessages;
+	}
+
+	private static takeMessagesAroundMiddle(messages: Message[], maxTokens: number): Message[] {
+		if (messages.length === 0) {
+			return messages;
+		}
+
+		const midPoint = Math.floor(messages.length / 2);
+		const selectedIndices = new Set<number>();
+		let usedTokens = 0;
+
+		const addIfFits = (index: number): boolean => {
+			if (selectedIndices.has(index)) {
+				return false;
+			}
+
+			const messageTokens = estimateMessageTokens(messages[index]);
+
+			if (selectedIndices.size === 0 && messageTokens > maxTokens) {
+				selectedIndices.add(index);
+				usedTokens = messageTokens;
+				return false;
+			}
+
+			if (usedTokens + messageTokens > maxTokens) {
+				return false;
+			}
+
+			selectedIndices.add(index);
+			usedTokens += messageTokens;
+			return true;
+		};
+
+		addIfFits(midPoint);
+
+		for (let offset = 1; offset < messages.length; offset += 1) {
+			let added = false;
+
+			if (midPoint - offset >= 0) {
+				added = addIfFits(midPoint - offset) || added;
+			}
+
+			if (midPoint + offset < messages.length) {
+				added = addIfFits(midPoint + offset) || added;
+			}
+
+			if (!added) {
+				if (midPoint - offset < 0 && midPoint + offset >= messages.length) {
+					break;
+				}
+			}
+		}
+
+		return [...selectedIndices]
+			.sort((left, right) => left - right)
+			.map((index) => messages[index]);
 	}
 
 	private static appendUniqueInstructionPart(
@@ -535,9 +611,9 @@ export class MessageFormatter {
 					? toolCall.id
 					: undefined;
 
-		if (!name || !callId) {
-			return null;
-		}
+			if (!name || !callId) {
+				return null;
+			}
 
 		return {
 			type: "function_call",

--- a/apps/api/src/lib/messageTokens.ts
+++ b/apps/api/src/lib/messageTokens.ts
@@ -46,10 +46,7 @@ export function estimateMessagesTokens(messages: Message[]): number {
 	return messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
 }
 
-export function estimateConversationTokens(
-	messages: Message[],
-	latestUserMessage: string,
-): number {
+export function estimateConversationTokens(messages: Message[], latestUserMessage: string): number {
 	const historyTokens = estimateMessagesTokens(messages);
 	return historyTokens + Math.ceil(latestUserMessage.length / CHARS_PER_TOKEN);
 }

--- a/apps/api/src/lib/messageTokens.ts
+++ b/apps/api/src/lib/messageTokens.ts
@@ -1,0 +1,55 @@
+import type { Message } from "~/types";
+
+const TOOL_RESULT_SUMMARY_LIMIT = 400;
+const CHARS_PER_TOKEN = 4;
+const TOOL_RESULT_CHARS_PER_TOKEN = 6;
+
+export function messageContentToText(content: Message["content"], role?: Message["role"]): string {
+	const truncateForTool = (text: string) => {
+		if (role === "tool" && text.length > TOOL_RESULT_SUMMARY_LIMIT) {
+			return text.slice(0, TOOL_RESULT_SUMMARY_LIMIT) + "…";
+		}
+		return text;
+	};
+
+	if (typeof content === "string") {
+		return truncateForTool(content);
+	}
+
+	if (Array.isArray(content)) {
+		const text = content
+			.map((part) =>
+				part.type === "text"
+					? part.text || ""
+					: part.type === "thinking"
+						? part.thinking || ""
+						: "",
+			)
+			.join("\n");
+		return truncateForTool(text);
+	}
+
+	try {
+		return truncateForTool(JSON.stringify(content));
+	} catch {
+		return "";
+	}
+}
+
+export function estimateMessageTokens(message: Message): number {
+	const text = messageContentToText(message.content, message.role);
+	const charsPerToken = message.role === "tool" ? TOOL_RESULT_CHARS_PER_TOKEN : CHARS_PER_TOKEN;
+	return Math.ceil(text.length / charsPerToken) + 4;
+}
+
+export function estimateMessagesTokens(messages: Message[]): number {
+	return messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+}
+
+export function estimateConversationTokens(
+	messages: Message[],
+	latestUserMessage: string,
+): number {
+	const historyTokens = estimateMessagesTokens(messages);
+	return historyTokens + Math.ceil(latestUserMessage.length / CHARS_PER_TOKEN);
+}

--- a/apps/api/src/lib/session/compaction.ts
+++ b/apps/api/src/lib/session/compaction.ts
@@ -1,4 +1,9 @@
 import type { Message } from "~/types";
+import {
+	messageContentToText,
+	estimateConversationTokens,
+	estimateMessageTokens,
+} from "~/lib/messageTokens";
 
 export interface CompactionWindowConfig {
 	contextWindow?: number;
@@ -20,52 +25,7 @@ const DEFAULT_TRIGGER_RATIO = 0.7;
 const DEFAULT_MIN_MESSAGES = 24;
 const DEFAULT_KEEP_RECENT_MESSAGES = 8;
 const DEFAULT_MIN_ARCHIVE_COUNT = 6;
-const TOOL_RESULT_SUMMARY_LIMIT = 400;
-
-function contentToText(content: Message["content"], role?: Message["role"]): string {
-	const truncateForTool = (text: string) => {
-		if (role === "tool" && text.length > TOOL_RESULT_SUMMARY_LIMIT) {
-			return text.slice(0, TOOL_RESULT_SUMMARY_LIMIT) + "…";
-		}
-		return text;
-	};
-
-	if (typeof content === "string") {
-		return truncateForTool(content);
-	}
-
-	if (Array.isArray(content)) {
-		const text = content
-			.map((part) =>
-				part.type === "text"
-					? part.text || ""
-					: part.type === "thinking"
-						? part.thinking || ""
-						: "",
-			)
-			.join("\n");
-		return truncateForTool(text);
-	}
-
-	try {
-		return truncateForTool(JSON.stringify(content));
-	} catch {
-		return "";
-	}
-}
-
-export function estimateMessageTokens(message: Message): number {
-	const text = contentToText(message.content, message.role);
-	// Tool results are often repetitive structured output; they compress more in
-	// practice than prose (~5–6 chars/token vs ~4 for natural language).
-	const charsPerToken = message.role === "tool" ? 6 : 4;
-	return Math.ceil(text.length / charsPerToken) + 4;
-}
-
-export function estimateConversationTokens(messages: Message[], latestUserMessage: string): number {
-	const historyTokens = messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
-	return historyTokens + Math.ceil(latestUserMessage.length / 4);
-}
+export { estimateConversationTokens, estimateMessageTokens };
 
 function hasSnapshotPart(message: Message): boolean {
 	return Array.isArray(message.parts) && message.parts.some((part) => part.type === "snapshot");
@@ -151,7 +111,7 @@ export function buildFallbackSummary(messages: Message[]): string {
 		.slice(-6)
 		.map((message) => {
 			const label = ROLE_LABELS[message.role] ?? `[${message.role}]`;
-			const text = contentToText(message.content, message.role);
+			const text = messageContentToText(message.content, message.role);
 			return `${label} ${text}`.trim();
 		})
 		.filter((line) => line.length > 0);
@@ -169,7 +129,7 @@ export function formatMessagesForSummary(messages: Message[], maxCharacters = 16
 
 	for (const message of messages) {
 		const label = ROLE_LABELS[message.role] ?? `[${message.role}]`;
-		const body = contentToText(message.content, message.role);
+		const body = messageContentToText(message.content, message.role);
 		if (!body) {
 			continue;
 		}


### PR DESCRIPTION
## Summary
- Unify API-side message token estimation in a shared `apps/api/src/lib/messageTokens.ts` utility.
- Reuse that estimation in compaction and formatter truncation paths.
- Replace heuristic length-based truncation with token-budget-aware truncation for `head`, `tail`, and `middle` strategies.
- Add tests for token-budget truncation coverage.

## Problem
- Token budgets were computed inconsistently between compaction and formatter paths.
- Truncation in `MessageFormatter` used message-length slicing and could drop more/less context than the configured token budget intended.
- This created unpredictable prompt payload sizes and weaker snapshot retention under compacting flows.

## API Impact
- `apps/api/src/lib/session/compaction.ts` now uses shared token estimation and keeps compaction decisions aligned with formatter/truncation behaviour.
- `apps/api/src/lib/formatter/messages.ts` truncates messages by estimated token budget, improving prompt size control before model/provider formatting.
- `apps/api/src/lib/formatter/__test__/messages.test.ts` now validates token-aware truncation for `head`, `tail`, and `middle`.

## Functional changes
- Added shared helpers in `apps/api/src/lib/messageTokens.ts`:
  - `messageContentToText`
  - `estimateMessageTokens`
  - `estimateMessagesTokens`
  - `estimateConversationTokens`
- Exported shared helpers via compaction module for compatibility.
- Updated truncation strategy implementation (`takeMessagesUntilTokenBudget`, `takeMessagesAroundMiddle`) to enforce token budgets without changing call sites.

## Validation
- `pnpm --filter @assistant/api exec vitest run src/lib/formatter/__test__/messages.test.ts src/lib/session/__test__/compaction.test.ts` (pass)
