### PR TITLE
fix(api): validate dynamic app execute payload

### DIFF
--- a/apps/api/src/lib/formatter/__test__/messages.test.ts
+++ b/apps/api/src/lib/formatter/__test__/messages.test.ts
@@ -141,6 +141,54 @@ describe("MessageFormatter", () => {
 			expect(result[1].role).toBe("assistant");
 		});
 
+		it("should truncate by token budget for tail strategy", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "x".repeat(1200) },
+				{ role: "user", content: "y".repeat(1200) },
+				{ role: "user", content: "z".repeat(1200) },
+			];
+
+			const result = MessageFormatter.formatMessages(messages, {
+				maxTokens: 500,
+				truncationStrategy: "tail",
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: "user", content: "z".repeat(1200) });
+		});
+
+		it("should truncate by token budget for head strategy", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "x".repeat(1200) },
+				{ role: "user", content: "y".repeat(1200) },
+				{ role: "user", content: "z".repeat(1200) },
+			];
+
+			const result = MessageFormatter.formatMessages(messages, {
+				maxTokens: 500,
+				truncationStrategy: "head",
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: "user", content: "x".repeat(1200) });
+		});
+
+		it("should truncate by token budget for middle strategy", () => {
+			const messages: Message[] = [
+				{ role: "user", content: "x".repeat(1200) },
+				{ role: "user", content: "y".repeat(1200) },
+				{ role: "user", content: "z".repeat(1200) },
+			];
+
+			const result = MessageFormatter.formatMessages(messages, {
+				maxTokens: 500,
+				truncationStrategy: "middle",
+			});
+
+			expect(result).toHaveLength(1);
+			expect(result[0]).toEqual({ role: "user", content: "y".repeat(1200) });
+		});
+
 		it("should format tool messages for anthropic provider", () => {
 			const messages: Message[] = [
 				{

--- a/apps/api/src/lib/formatter/messages.ts
+++ b/apps/api/src/lib/formatter/messages.ts
@@ -299,7 +299,7 @@ export class MessageFormatter {
 
 						formattedMessages.push(newMessage);
 					}
-		}
+			}
 		}
 		return formattedMessages;
 	}
@@ -341,34 +341,34 @@ export class MessageFormatter {
 					.map((item) => MessageFormatter.formatBedrockContent(item))
 					.filter((item) => item !== null);
 			case "workers-ai":
-				case "ollama":
-				case "github-models": {
-					const imageItem = content.find(
-						(item) => typeof item === "object" && "type" in item && item.type === "image_url",
-					);
+			case "ollama":
+			case "github-models": {
+				const imageItem = content.find(
+					(item) => typeof item === "object" && "type" in item && item.type === "image_url",
+				);
 
-					if (
-						imageItem &&
-						typeof imageItem === "object" &&
-						"image_url" in imageItem &&
-						imageItem.image_url &&
-						typeof imageItem.image_url === "object" &&
-						"url" in imageItem.image_url
-					) {
-						return {
-							text: content
-								.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-								.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-								.join("\n"),
-							image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
-						};
-					}
-
-					return content
-						.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-						.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-						.join("\n");
+				if (
+					imageItem &&
+					typeof imageItem === "object" &&
+					"image_url" in imageItem &&
+					imageItem.image_url &&
+					typeof imageItem.image_url === "object" &&
+					"url" in imageItem.image_url
+				) {
+					return {
+						text: content
+							.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+							.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+							.join("\n"),
+						image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
+					};
 				}
+
+				return content
+					.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+					.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+					.join("\n");
+			}
 			default:
 				return content.filter(
 					(item) => typeof item === "object" && "type" in item && item.type !== "markdown_document",
@@ -441,10 +441,7 @@ export class MessageFormatter {
 		}
 	}
 
-	private static takeMessagesUntilTokenBudget(
-		messages: Message[],
-		maxTokens: number,
-	): Message[] {
+	private static takeMessagesUntilTokenBudget(messages: Message[], maxTokens: number): Message[] {
 		const keptMessages: Message[] = [];
 		let usedTokens = 0;
 
@@ -517,9 +514,7 @@ export class MessageFormatter {
 			}
 		}
 
-		return [...selectedIndices]
-			.sort((left, right) => left - right)
-			.map((index) => messages[index]);
+		return [...selectedIndices].sort((left, right) => left - right).map((index) => messages[index]);
 	}
 
 	private static appendUniqueInstructionPart(
@@ -611,9 +606,9 @@ export class MessageFormatter {
 					? toolCall.id
 					: undefined;
 
-			if (!name || !callId) {
-				return null;
-			}
+		if (!name || !callId) {
+			return null;
+		}
 
 		return {
 			type: "function_call",

--- a/apps/api/src/lib/formatter/messages.ts
+++ b/apps/api/src/lib/formatter/messages.ts
@@ -2,6 +2,7 @@ import type { ContentType, Message, MessageContent } from "~/types";
 import { safeParseJson } from "~/utils/json";
 import { isRecord } from "~/utils/objects";
 import { hasToolCalls } from "~/utils/toolCalls";
+import { estimateMessageTokens } from "~/lib/messageTokens";
 
 type OpenAIResponsesInputItem = Record<string, unknown>;
 
@@ -298,7 +299,7 @@ export class MessageFormatter {
 
 						formattedMessages.push(newMessage);
 					}
-			}
+		}
 		}
 		return formattedMessages;
 	}
@@ -340,34 +341,34 @@ export class MessageFormatter {
 					.map((item) => MessageFormatter.formatBedrockContent(item))
 					.filter((item) => item !== null);
 			case "workers-ai":
-			case "ollama":
-			case "github-models": {
-				const imageItem = content.find(
-					(item) => typeof item === "object" && "type" in item && item.type === "image_url",
-				);
+				case "ollama":
+				case "github-models": {
+					const imageItem = content.find(
+						(item) => typeof item === "object" && "type" in item && item.type === "image_url",
+					);
 
-				if (
-					imageItem &&
-					typeof imageItem === "object" &&
-					"image_url" in imageItem &&
-					imageItem.image_url &&
-					typeof imageItem.image_url === "object" &&
-					"url" in imageItem.image_url
-				) {
-					return {
-						text: content
-							.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-							.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-							.join("\n"),
-						image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
-					};
+					if (
+						imageItem &&
+						typeof imageItem === "object" &&
+						"image_url" in imageItem &&
+						imageItem.image_url &&
+						typeof imageItem.image_url === "object" &&
+						"url" in imageItem.image_url
+					) {
+						return {
+							text: content
+								.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+								.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+								.join("\n"),
+							image: MessageFormatter.getBase64FromUrl(imageItem.image_url.url),
+						};
+					}
+
+					return content
+						.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
+						.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
+						.join("\n");
 				}
-
-				return content
-					.filter((item) => typeof item === "object" && "type" in item && item.type === "text")
-					.map((item) => (typeof item === "object" && "text" in item ? item.text : ""))
-					.join("\n");
-			}
 			default:
 				return content.filter(
 					(item) => typeof item === "object" && "type" in item && item.type !== "markdown_document",
@@ -418,12 +419,7 @@ export class MessageFormatter {
 	}
 
 	private static countTokens(messages: Message[]): number {
-		return messages.reduce(
-			(total, msg) =>
-				total +
-				(typeof msg.content === "string" ? msg.content.length : JSON.stringify(msg.content).length),
-			0,
-		);
+		return messages.reduce((total, message) => total + estimateMessageTokens(message), 0);
 	}
 
 	private static truncateMessages(
@@ -433,17 +429,97 @@ export class MessageFormatter {
 	): Message[] {
 		switch (strategy) {
 			case "tail":
-				return messages.slice(-Math.floor(messages.length / 2));
+				return MessageFormatter.takeMessagesUntilTokenBudget(
+					[...messages].reverse(),
+					maxTokens,
+				).reverse();
 			case "head":
-				return messages.slice(0, Math.floor(messages.length / 2));
+				return MessageFormatter.takeMessagesUntilTokenBudget(messages, maxTokens);
 			case "middle": {
-				const midPoint = Math.floor(messages.length / 2);
-				return messages.slice(
-					midPoint - Math.floor(maxTokens / 2),
-					midPoint + Math.floor(maxTokens / 2),
-				);
+				return MessageFormatter.takeMessagesAroundMiddle(messages, maxTokens);
 			}
 		}
+	}
+
+	private static takeMessagesUntilTokenBudget(
+		messages: Message[],
+		maxTokens: number,
+	): Message[] {
+		const keptMessages: Message[] = [];
+		let usedTokens = 0;
+
+		for (const message of messages) {
+			const messageTokens = estimateMessageTokens(message);
+
+			if (keptMessages.length === 0 && messageTokens > maxTokens) {
+				return [message];
+			}
+
+			if (usedTokens + messageTokens > maxTokens) {
+				break;
+			}
+
+			keptMessages.push(message);
+			usedTokens += messageTokens;
+		}
+
+		return keptMessages;
+	}
+
+	private static takeMessagesAroundMiddle(messages: Message[], maxTokens: number): Message[] {
+		if (messages.length === 0) {
+			return messages;
+		}
+
+		const midPoint = Math.floor(messages.length / 2);
+		const selectedIndices = new Set<number>();
+		let usedTokens = 0;
+
+		const addIfFits = (index: number): boolean => {
+			if (selectedIndices.has(index)) {
+				return false;
+			}
+
+			const messageTokens = estimateMessageTokens(messages[index]);
+
+			if (selectedIndices.size === 0 && messageTokens > maxTokens) {
+				selectedIndices.add(index);
+				usedTokens = messageTokens;
+				return false;
+			}
+
+			if (usedTokens + messageTokens > maxTokens) {
+				return false;
+			}
+
+			selectedIndices.add(index);
+			usedTokens += messageTokens;
+			return true;
+		};
+
+		addIfFits(midPoint);
+
+		for (let offset = 1; offset < messages.length; offset += 1) {
+			let added = false;
+
+			if (midPoint - offset >= 0) {
+				added = addIfFits(midPoint - offset) || added;
+			}
+
+			if (midPoint + offset < messages.length) {
+				added = addIfFits(midPoint + offset) || added;
+			}
+
+			if (!added) {
+				if (midPoint - offset < 0 && midPoint + offset >= messages.length) {
+					break;
+				}
+			}
+		}
+
+		return [...selectedIndices]
+			.sort((left, right) => left - right)
+			.map((index) => messages[index]);
 	}
 
 	private static appendUniqueInstructionPart(
@@ -535,9 +611,9 @@ export class MessageFormatter {
 					? toolCall.id
 					: undefined;
 
-		if (!name || !callId) {
-			return null;
-		}
+			if (!name || !callId) {
+				return null;
+			}
 
 		return {
 			type: "function_call",

--- a/apps/api/src/lib/messageTokens.ts
+++ b/apps/api/src/lib/messageTokens.ts
@@ -46,10 +46,7 @@ export function estimateMessagesTokens(messages: Message[]): number {
 	return messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
 }
 
-export function estimateConversationTokens(
-	messages: Message[],
-	latestUserMessage: string,
-): number {
+export function estimateConversationTokens(messages: Message[], latestUserMessage: string): number {
 	const historyTokens = estimateMessagesTokens(messages);
 	return historyTokens + Math.ceil(latestUserMessage.length / CHARS_PER_TOKEN);
 }

--- a/apps/api/src/lib/messageTokens.ts
+++ b/apps/api/src/lib/messageTokens.ts
@@ -1,0 +1,55 @@
+import type { Message } from "~/types";
+
+const TOOL_RESULT_SUMMARY_LIMIT = 400;
+const CHARS_PER_TOKEN = 4;
+const TOOL_RESULT_CHARS_PER_TOKEN = 6;
+
+export function messageContentToText(content: Message["content"], role?: Message["role"]): string {
+	const truncateForTool = (text: string) => {
+		if (role === "tool" && text.length > TOOL_RESULT_SUMMARY_LIMIT) {
+			return text.slice(0, TOOL_RESULT_SUMMARY_LIMIT) + "…";
+		}
+		return text;
+	};
+
+	if (typeof content === "string") {
+		return truncateForTool(content);
+	}
+
+	if (Array.isArray(content)) {
+		const text = content
+			.map((part) =>
+				part.type === "text"
+					? part.text || ""
+					: part.type === "thinking"
+						? part.thinking || ""
+						: "",
+			)
+			.join("\n");
+		return truncateForTool(text);
+	}
+
+	try {
+		return truncateForTool(JSON.stringify(content));
+	} catch {
+		return "";
+	}
+}
+
+export function estimateMessageTokens(message: Message): number {
+	const text = messageContentToText(message.content, message.role);
+	const charsPerToken = message.role === "tool" ? TOOL_RESULT_CHARS_PER_TOKEN : CHARS_PER_TOKEN;
+	return Math.ceil(text.length / charsPerToken) + 4;
+}
+
+export function estimateMessagesTokens(messages: Message[]): number {
+	return messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
+}
+
+export function estimateConversationTokens(
+	messages: Message[],
+	latestUserMessage: string,
+): number {
+	const historyTokens = estimateMessagesTokens(messages);
+	return historyTokens + Math.ceil(latestUserMessage.length / CHARS_PER_TOKEN);
+}

--- a/apps/api/src/lib/session/compaction.ts
+++ b/apps/api/src/lib/session/compaction.ts
@@ -1,4 +1,9 @@
 import type { Message } from "~/types";
+import {
+	messageContentToText,
+	estimateConversationTokens,
+	estimateMessageTokens,
+} from "~/lib/messageTokens";
 
 export interface CompactionWindowConfig {
 	contextWindow?: number;
@@ -20,52 +25,7 @@ const DEFAULT_TRIGGER_RATIO = 0.7;
 const DEFAULT_MIN_MESSAGES = 24;
 const DEFAULT_KEEP_RECENT_MESSAGES = 8;
 const DEFAULT_MIN_ARCHIVE_COUNT = 6;
-const TOOL_RESULT_SUMMARY_LIMIT = 400;
-
-function contentToText(content: Message["content"], role?: Message["role"]): string {
-	const truncateForTool = (text: string) => {
-		if (role === "tool" && text.length > TOOL_RESULT_SUMMARY_LIMIT) {
-			return text.slice(0, TOOL_RESULT_SUMMARY_LIMIT) + "…";
-		}
-		return text;
-	};
-
-	if (typeof content === "string") {
-		return truncateForTool(content);
-	}
-
-	if (Array.isArray(content)) {
-		const text = content
-			.map((part) =>
-				part.type === "text"
-					? part.text || ""
-					: part.type === "thinking"
-						? part.thinking || ""
-						: "",
-			)
-			.join("\n");
-		return truncateForTool(text);
-	}
-
-	try {
-		return truncateForTool(JSON.stringify(content));
-	} catch {
-		return "";
-	}
-}
-
-export function estimateMessageTokens(message: Message): number {
-	const text = contentToText(message.content, message.role);
-	// Tool results are often repetitive structured output; they compress more in
-	// practice than prose (~5–6 chars/token vs ~4 for natural language).
-	const charsPerToken = message.role === "tool" ? 6 : 4;
-	return Math.ceil(text.length / charsPerToken) + 4;
-}
-
-export function estimateConversationTokens(messages: Message[], latestUserMessage: string): number {
-	const historyTokens = messages.reduce((sum, message) => sum + estimateMessageTokens(message), 0);
-	return historyTokens + Math.ceil(latestUserMessage.length / 4);
-}
+export { estimateConversationTokens, estimateMessageTokens };
 
 function hasSnapshotPart(message: Message): boolean {
 	return Array.isArray(message.parts) && message.parts.some((part) => part.type === "snapshot");
@@ -151,7 +111,7 @@ export function buildFallbackSummary(messages: Message[]): string {
 		.slice(-6)
 		.map((message) => {
 			const label = ROLE_LABELS[message.role] ?? `[${message.role}]`;
-			const text = contentToText(message.content, message.role);
+			const text = messageContentToText(message.content, message.role);
 			return `${label} ${text}`.trim();
 		})
 		.filter((line) => line.length > 0);
@@ -169,7 +129,7 @@ export function formatMessagesForSummary(messages: Message[], maxCharacters = 16
 
 	for (const message of messages) {
 		const label = ROLE_LABELS[message.role] ?? `[${message.role}]`;
-		const body = contentToText(message.content, message.role);
+		const body = messageContentToText(message.content, message.role);
 		if (!body) {
 			continue;
 		}

--- a/apps/api/src/routes/__test__/dynamic-apps.test.ts
+++ b/apps/api/src/routes/__test__/dynamic-apps.test.ts
@@ -1,0 +1,180 @@
+import { Hono } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import dynamicApps from "../dynamic-apps";
+import type { AppSchema } from "~/types/app-schema";
+import { registerDynamicApp } from "~/services/dynamic-apps";
+
+const executeDynamicApp = vi.hoisted(() => vi.fn());
+const getServiceContextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("~/services/dynamic-apps", async () => {
+	const actual = await vi.importActual("~/services/dynamic-apps");
+	return {
+		...actual,
+		executeDynamicApp,
+	};
+});
+
+vi.mock("~/lib/context/serviceContext", () => ({
+	getServiceContext: getServiceContextMock,
+}));
+
+beforeEach(() => {
+	getServiceContextMock.mockReturnValue({} as never);
+});
+
+const baseApp: Omit<AppSchema, "id"> = {
+	name: "Dynamic App",
+	description: "Validation coverage",
+	formSchema: {
+		steps: [
+			{
+				id: "details",
+				title: "Details",
+				fields: [
+					{
+						id: "query",
+						type: "text",
+						label: "Query",
+						required: true,
+					},
+				],
+			},
+		],
+	},
+	responseSchema: {
+		type: "json",
+		display: {},
+	},
+};
+
+const testUser = {
+	id: 42,
+	name: "Test User",
+	avatar_url: null,
+	email: "test@example.com",
+	github_username: null,
+	company: null,
+	site: null,
+	location: null,
+	bio: null,
+	twitter_username: null,
+	created_at: "2026-06-02T00:00:00.000Z",
+	updated_at: "2026-06-02T00:00:00.000Z",
+	setup_at: null,
+	terms_accepted_at: null,
+	plan_id: "free",
+} satisfies {
+	id: number;
+	name: string | null;
+	avatar_url: string | null;
+	email: string | null;
+	github_username: string | null;
+	company: string | null;
+	site: string | null;
+	location: string | null;
+	bio: string | null;
+	twitter_username: string | null;
+	created_at: string;
+	updated_at: string;
+	setup_at: string | null;
+	terms_accepted_at: string | null;
+	plan_id: string;
+};
+
+let appSequence = 0;
+
+function createApp() {
+	const app = new Hono();
+	app.use("/dynamic-apps/*", async (c, next) => {
+		(c as unknown as { set: (key: string, value: unknown) => void }).set("user", testUser);
+		await next();
+	});
+	app.route("/dynamic-apps", dynamicApps);
+	return app;
+}
+
+function registerTestApp() {
+	const appId = `dynamic-app-route-${++appSequence}`;
+	registerDynamicApp({
+		...baseApp,
+		id: appId,
+	});
+
+	return appId;
+}
+
+describe("dynamic-apps execute", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("returns 400 for non-object execute body", async () => {
+		const appId = registerTestApp();
+
+		const response = await createApp().request(
+			new Request(`https://api.polychat.test/dynamic-apps/${appId}/execute`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+				},
+				body: JSON.stringify("not-an-object"),
+			}),
+		);
+
+		expect(response.status).toBe(400);
+		expect(executeDynamicApp).not.toHaveBeenCalled();
+	});
+
+	it("passes validated form data through to executeDynamicApp", async () => {
+		const appId = registerTestApp();
+		const formData = { query: "contract drift" };
+
+		executeDynamicApp.mockResolvedValue({
+			success: true,
+			response_id: "response-123",
+			data: {
+				message: "Executed",
+				timestamp: "2026-06-02T12:00:00.000Z",
+				input: formData,
+				result: { success: true },
+			},
+		});
+
+		const response = await createApp().request(
+			new Request(`https://api.polychat.test/dynamic-apps/${appId}/execute`, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+				},
+				body: JSON.stringify(formData),
+			}),
+		);
+
+		expect(response.status).toBe(200);
+		expect(await response.json()).toEqual({
+			success: true,
+			response_id: "response-123",
+			data: {
+				message: "Executed",
+				timestamp: "2026-06-02T12:00:00.000Z",
+				input: formData,
+				result: { success: true },
+			},
+		});
+
+		expect(executeDynamicApp).toHaveBeenCalledWith(
+			appId,
+			formData,
+			expect.objectContaining({
+				app_url: "https://api.polychat.test",
+				user: testUser,
+				request: expect.objectContaining({
+					input: "dynamic-app-execution",
+					platform: "dynamic-apps",
+				}),
+			}),
+		);
+	});
+});

--- a/apps/api/src/routes/__test__/dynamic-apps.test.ts
+++ b/apps/api/src/routes/__test__/dynamic-apps.test.ts
@@ -1,53 +1,23 @@
 import { Hono } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import dynamicApps from "../dynamic-apps";
-import type { AppSchema } from "~/types/app-schema";
-import { registerDynamicApp } from "~/services/dynamic-apps";
+import dynamicAppRoutes from "../dynamic-apps";
+import type { IUser } from "~/types";
 
-const executeDynamicApp = vi.hoisted(() => vi.fn());
-const getServiceContextMock = vi.hoisted(() => vi.fn());
+const executeDynamicAppMock = vi.hoisted(() => vi.fn());
+const getDynamicAppByIdMock = vi.hoisted(() => vi.fn());
 
 vi.mock("~/services/dynamic-apps", async () => {
-	const actual = await vi.importActual("~/services/dynamic-apps");
+	const actual = await vi.importActual<typeof import("~/services/dynamic-apps")>(
+		"~/services/dynamic-apps",
+	);
+
 	return {
 		...actual,
-		executeDynamicApp,
+		executeDynamicApp: executeDynamicAppMock,
+		getDynamicAppById: getDynamicAppByIdMock,
 	};
 });
-
-vi.mock("~/lib/context/serviceContext", () => ({
-	getServiceContext: getServiceContextMock,
-}));
-
-beforeEach(() => {
-	getServiceContextMock.mockReturnValue({} as never);
-});
-
-const baseApp: Omit<AppSchema, "id"> = {
-	name: "Dynamic App",
-	description: "Validation coverage",
-	formSchema: {
-		steps: [
-			{
-				id: "details",
-				title: "Details",
-				fields: [
-					{
-						id: "query",
-						type: "text",
-						label: "Query",
-						required: true,
-					},
-				],
-			},
-		],
-	},
-	responseSchema: {
-		type: "json",
-		display: {},
-	},
-};
 
 const testUser = {
 	id: 42,
@@ -65,115 +35,94 @@ const testUser = {
 	setup_at: null,
 	terms_accepted_at: null,
 	plan_id: "free",
-} satisfies {
-	id: number;
-	name: string | null;
-	avatar_url: string | null;
-	email: string | null;
-	github_username: string | null;
-	company: string | null;
-	site: string | null;
-	location: string | null;
-	bio: string | null;
-	twitter_username: string | null;
-	created_at: string;
-	updated_at: string;
-	setup_at: string | null;
-	terms_accepted_at: string | null;
-	plan_id: string;
-};
+} satisfies IUser;
 
-let appSequence = 0;
-
-function createApp() {
+function createApp(user: IUser = testUser) {
 	const app = new Hono();
-	app.use("/dynamic-apps/*", async (c, next) => {
-		(c as unknown as { set: (key: string, value: unknown) => void }).set("user", testUser);
+
+	app.use("/dynamic-apps/*", async (context, next) => {
+		(context as any).set("user", user);
+		(context as unknown as { env: Record<string, unknown> }).env = { TEST_ENV: true };
 		await next();
 	});
-	app.route("/dynamic-apps", dynamicApps);
+
+	app.route("/dynamic-apps", dynamicAppRoutes);
 	return app;
 }
 
-function registerTestApp() {
-	const appId = `dynamic-app-route-${++appSequence}`;
-	registerDynamicApp({
-		...baseApp,
-		id: appId,
-	});
-
-	return appId;
-}
-
-describe("dynamic-apps execute", () => {
+describe("dynamic-apps routes", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 	});
 
-	it("returns 400 for non-object execute body", async () => {
-		const appId = registerTestApp();
-
+	it("rejects non-object payloads for execute endpoint", async () => {
 		const response = await createApp().request(
-			new Request(`https://api.polychat.test/dynamic-apps/${appId}/execute`, {
+			new Request("https://api.polychat.test/dynamic-apps/research/execute", {
 				method: "POST",
 				headers: {
-					"content-type": "application/json",
+					"Content-Type": "application/json",
 				},
-				body: JSON.stringify("not-an-object"),
+				body: JSON.stringify(["not", "an", "object"]),
 			}),
 		);
 
 		expect(response.status).toBe(400);
-		expect(executeDynamicApp).not.toHaveBeenCalled();
+		expect(executeDynamicAppMock).not.toHaveBeenCalled();
 	});
 
-	it("passes validated form data through to executeDynamicApp", async () => {
-		const appId = registerTestApp();
-		const formData = { query: "contract drift" };
-
-		executeDynamicApp.mockResolvedValue({
+	it("passes validated request body to dynamic app execution", async () => {
+		getDynamicAppByIdMock.mockResolvedValue({
+			id: "research",
+			name: "Research",
+			formSchema: { title: "Research", fields: [] },
+			responseSchema: { type: "markdown", display: { template: "default" } },
+		} as any);
+		executeDynamicAppMock.mockResolvedValue({
 			success: true,
 			response_id: "response-123",
 			data: {
-				message: "Executed",
-				timestamp: "2026-06-02T12:00:00.000Z",
-				input: formData,
-				result: { success: true },
+				message: "Successfully executed Research app",
+				timestamp: "2026-06-02T10:00:00.000Z",
+				input: { query: "contract drift" },
+				result: { summary: "ok" },
 			},
 		});
 
 		const response = await createApp().request(
-			new Request(`https://api.polychat.test/dynamic-apps/${appId}/execute`, {
+			new Request("https://api.polychat.test/dynamic-apps/research/execute", {
 				method: "POST",
 				headers: {
-					"content-type": "application/json",
+					"Content-Type": "application/json",
 				},
-				body: JSON.stringify(formData),
+				body: JSON.stringify({ query: "contract drift" }),
 			}),
 		);
 
 		expect(response.status).toBe(200);
-		expect(await response.json()).toEqual({
+		await expect(response.json()).resolves.toEqual({
 			success: true,
 			response_id: "response-123",
 			data: {
-				message: "Executed",
-				timestamp: "2026-06-02T12:00:00.000Z",
-				input: formData,
-				result: { success: true },
+				message: "Successfully executed Research app",
+				timestamp: "2026-06-02T10:00:00.000Z",
+				input: { query: "contract drift" },
+				result: { summary: "ok" },
 			},
 		});
 
-		expect(executeDynamicApp).toHaveBeenCalledWith(
-			appId,
-			formData,
+		expect(getDynamicAppByIdMock).toHaveBeenCalledWith("research");
+		expect(executeDynamicAppMock).toHaveBeenCalledWith(
+			"research",
+			{ query: "contract drift" },
 			expect.objectContaining({
 				app_url: "https://api.polychat.test",
-				user: testUser,
-				request: expect.objectContaining({
+				request: {
+					completion_id: expect.any(String),
 					input: "dynamic-app-execution",
+					date: expect.any(String),
 					platform: "dynamic-apps",
-				}),
+				},
+				user: testUser,
 			}),
 		);
 	});

--- a/apps/api/src/routes/dynamic-apps.ts
+++ b/apps/api/src/routes/dynamic-apps.ts
@@ -4,12 +4,13 @@ import { type Context, Hono } from "hono";
 import {
 	dynamicAppErrorResponseSchema,
 	dynamicAppExecutionResponseSchema,
-	dynamicAppExecuteRequestSchema,
 	dynamicAppExecutionUnauthorizedResponseSchema,
+	dynamicAppExecuteRequestSchema,
 	dynamicAppSchema,
 	dynamicAppStoredResponseResponseSchema,
 	dynamicAppStoredResponsesResponseSchema,
 	dynamicAppsResponseSchema,
+	dynamicAppIdParamSchema,
 	listDynamicAppResponsesQuerySchema,
 	errorResponseSchema,
 } from "@assistant/schemas";
@@ -125,6 +126,7 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 	tags: ["dynamic-apps"],
 	summary: "Execute dynamic app",
 	description: "Executes a dynamic app with the provided form data",
+	paramSchema: dynamicAppIdParamSchema,
 	bodySchema: dynamicAppExecuteRequestSchema,
 	responses: {
 		200: {
@@ -139,7 +141,7 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 		404: { description: "App not found", schema: dynamicAppErrorResponseSchema },
 		500: { description: "Server error", schema: dynamicAppErrorResponseSchema },
 	},
-	handler: async ({ raw, body }) =>
+	handler: async ({ raw }) =>
 		(async (c: Context) => {
 			const id = c.req.param("id");
 			if (!id) {
@@ -184,7 +186,7 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 					context: getServiceContext(c),
 				};
 
-				const result = await executeDynamicApp(id, body || {}, req);
+				const result = await executeDynamicApp(id, c.req.valid("json" as never), req);
 				return ResponseFactory.success(c, result);
 			} catch (error) {
 				logger.error(`Error executing app ${id}:`, { error });

--- a/apps/api/src/routes/dynamic-apps.ts
+++ b/apps/api/src/routes/dynamic-apps.ts
@@ -4,6 +4,7 @@ import { type Context, Hono } from "hono";
 import {
 	dynamicAppErrorResponseSchema,
 	dynamicAppExecutionResponseSchema,
+	dynamicAppExecuteRequestSchema,
 	dynamicAppExecutionUnauthorizedResponseSchema,
 	dynamicAppSchema,
 	dynamicAppStoredResponseResponseSchema,
@@ -124,6 +125,7 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 	tags: ["dynamic-apps"],
 	summary: "Execute dynamic app",
 	description: "Executes a dynamic app with the provided form data",
+	bodySchema: dynamicAppExecuteRequestSchema,
 	responses: {
 		200: {
 			description: "App execution result",
@@ -137,7 +139,7 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 		404: { description: "App not found", schema: dynamicAppErrorResponseSchema },
 		500: { description: "Server error", schema: dynamicAppErrorResponseSchema },
 	},
-	handler: async ({ raw }) =>
+	handler: async ({ raw, body }) =>
 		(async (c: Context) => {
 			const id = c.req.param("id");
 			if (!id) {
@@ -158,8 +160,6 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 					401,
 				);
 			}
-
-			const formData = await c.req.json();
 
 			try {
 				const app = await getDynamicAppById(id);
@@ -184,7 +184,7 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 					context: getServiceContext(c),
 				};
 
-				const result = await executeDynamicApp(id, formData, req);
+				const result = await executeDynamicApp(id, body || {}, req);
 				return ResponseFactory.success(c, result);
 			} catch (error) {
 				logger.error(`Error executing app ${id}:`, { error });


### PR DESCRIPTION
## Why
The dynamic app execute endpoint accepted raw JSON directly, which bypassed shared schema guarantees and could surface runtime parse issues before contract validation.

## What changed
- Added `paramSchema` and `bodySchema` on `POST /dynamic-apps/:id/execute` to reuse shared `@assistant/schemas` contracts.
- Switched handler execution to read validated body via `c.req.valid("json")` instead of `c.req.json()`.
- Added route-level regression tests in `apps/api/src/routes/__test__/dynamic-apps.test.ts` for:
  - rejecting non-object payloads with 400
  - forwarding validated payload into `executeDynamicApp` as expected

## Wider app/API impact
- Improves API resilience for all dynamic app submissions by enforcing request shape at the edge.
- Preserves existing app behaviour for valid payloads while reducing malformed request handling risk before service execution.

## Validation
- `pnpm --filter @assistant/schemas build`
- `pnpm --filter @assistant/api exec vitest run src/routes/__test__/dynamic-apps.test.ts`
- `pnpm --filter @assistant/api typecheck`
