### PR TITLE
Refactor API route/service boundaries

### DIFF
--- a/apps/api/src/routes/assets.ts
+++ b/apps/api/src/routes/assets.ts
@@ -1,40 +1,37 @@
 import { Hono } from "hono";
+import z from "zod/v4";
 
-import { getServiceContext } from "~/lib/context/serviceContext";
+import { addRoute } from "~/lib/http/routeBuilder";
 import { createRouteLogger } from "~/middleware/loggerMiddleware";
-import { readAsset } from "~/lib/storage/read-asset";
+import { getAssetResponsePayload } from "~/services/assets";
 
 const app = new Hono();
 const routeLogger = createRouteLogger("assets");
-
-async function buildAssetResponse(asset: Awaited<ReturnType<typeof readAsset>>): Promise<Response> {
-	const headers = new Headers();
-	headers.set("content-type", asset.asset.mime_type);
-	headers.set("cache-control", "private, no-store");
-	headers.set("cross-origin-resource-policy", "cross-origin");
-	if (asset.asset.filename) {
-		headers.set("content-disposition", `inline; filename="${asset.asset.filename}"`);
-	}
-
-	return new Response(await asset.object.arrayBuffer(), {
-		headers,
-	});
-}
 
 app.use("/*", (c, next) => {
 	routeLogger.info(`Processing assets route: ${c.req.path}`);
 	return next();
 });
 
-app.get("/:assetId", async (context) => {
-	const serviceContext = getServiceContext(context);
-	const asset = await readAsset({
-		context: serviceContext,
-		assetId: context.req.param("assetId"),
-		userId: serviceContext.user?.id,
-	});
+addRoute(app, "get", "/:assetId", {
+	tags: ["assets"],
+	summary: "Read a stored asset",
+	paramSchema: z.object({ assetId: z.string().min(1) }),
+	responses: {
+		200: { description: "Asset bytes" },
+		403: { description: "Asset access denied" },
+		404: { description: "Asset not found" },
+	},
+	handler: async ({ params, serviceContext }) => {
+		const asset = await getAssetResponsePayload({
+			context: serviceContext,
+			assetId: params.assetId,
+		});
 
-	return await buildAssetResponse(asset);
+		return new Response(asset.body, {
+			headers: asset.headers,
+		});
+	},
 });
 
 export default app;

--- a/apps/api/src/routes/dynamic-apps.ts
+++ b/apps/api/src/routes/dynamic-apps.ts
@@ -1,5 +1,5 @@
-import { addRoute } from "~/lib/http/routeBuilder";
-import { type Context, Hono } from "hono";
+import { Hono } from "hono";
+import z from "zod/v4";
 
 import {
 	dynamicAppErrorResponseSchema,
@@ -13,30 +13,25 @@ import {
 	errorResponseSchema,
 } from "@assistant/schemas";
 
-import { requireAuth } from "~/middleware/auth";
+import { addRoute } from "~/lib/http/routeBuilder";
 import { createRouteLogger } from "~/middleware/loggerMiddleware";
-import { ResponseFactory } from "~/lib/http/ResponseFactory";
 import {
 	executeDynamicApp,
 	getDynamicAppById,
 	getDynamicAppCatalog,
-	listDynamicAppResponsesForUser,
 	getDynamicAppResponseById,
+	listDynamicAppResponsesForUser,
 } from "~/services/dynamic-apps";
 import type { IRequest } from "~/types/chat";
-import type { IEnv } from "~/types/shared";
-import { getLogger } from "~/utils/logger";
-import type { IUser } from "../types";
+import { AssistantError, ErrorType } from "~/utils/errors";
 import { generateId } from "~/utils/id";
-import { getServiceContext } from "~/lib/context/serviceContext";
-
-const logger = getLogger({ prefix: "routes/dynamic-apps" });
 
 const dynamicApps = new Hono();
-
 const routeLogger = createRouteLogger("dynamic-apps");
 
-dynamicApps.use("*", requireAuth);
+const dynamicAppParamsSchema = z.object({ id: z.string().min(1) });
+const dynamicAppResponseParamsSchema = z.object({ responseId: z.string().min(1) });
+const dynamicAppExecutionBodySchema = z.record(z.string(), z.any());
 
 dynamicApps.use("*", (c, next) => {
 	routeLogger.info(`Processing dynamic-apps route: ${c.req.path}`);
@@ -47,6 +42,7 @@ addRoute(dynamicApps, "get", "/", {
 	tags: ["dynamic-apps"],
 	summary: "List all available dynamic apps",
 	description: "Returns a list of all registered dynamic apps with their basic information",
+	auth: true,
 	responses: {
 		200: {
 			description: "Dynamic apps and featured listings",
@@ -57,17 +53,15 @@ addRoute(dynamicApps, "get", "/", {
 			schema: errorResponseSchema,
 		},
 	},
-	handler: async ({ raw }) =>
-		(async (c) => {
-			return ResponseFactory.success(c, {
-				apps: await getDynamicAppCatalog(),
-			});
-		})(raw),
+	handler: async () => ({
+		apps: await getDynamicAppCatalog(),
+	}),
 });
 
 addRoute(dynamicApps, "get", "/responses", {
 	tags: ["dynamic-apps"],
 	summary: "List stored dynamic-app responses for user",
+	auth: true,
 	querySchema: listDynamicAppResponsesQuerySchema,
 	responses: {
 		200: { description: "Array of responses", schema: dynamicAppStoredResponsesResponseSchema },
@@ -76,22 +70,16 @@ addRoute(dynamicApps, "get", "/responses", {
 			schema: errorResponseSchema,
 		},
 	},
-	handler: async ({ raw }) =>
-		(async (c: Context) => {
-			const user = c.get("user") as IUser;
-			const { appId } = c.req.valid("query" as never) as {
-				appId?: string;
-			};
-
-			const list = await listDynamicAppResponsesForUser(c.env as IEnv, user.id, appId);
-			return ResponseFactory.success(c, list);
-		})(raw),
+	handler: async ({ query, serviceContext, user }) =>
+		listDynamicAppResponsesForUser(serviceContext, user.id, query.appId),
 });
 
 addRoute(dynamicApps, "get", "/:id", {
 	tags: ["dynamic-apps"],
 	summary: "Get dynamic app schema",
 	description: "Returns the complete schema for a specific dynamic app",
+	auth: true,
+	paramSchema: dynamicAppParamsSchema,
 	responses: {
 		200: { description: "Dynamic app schema", schema: dynamicAppSchema },
 		400: { description: "Bad request", schema: dynamicAppErrorResponseSchema },
@@ -101,29 +89,23 @@ addRoute(dynamicApps, "get", "/:id", {
 		},
 		404: { description: "App not found", schema: dynamicAppErrorResponseSchema },
 	},
-	handler: async ({ raw }) =>
-		(async (c: Context) => {
-			const _user = c.get("user") as IUser | undefined;
+	handler: async ({ params }) => {
+		const app = await getDynamicAppById(params.id);
+		if (!app) {
+			throw new AssistantError("App not found", ErrorType.NOT_FOUND, 404);
+		}
 
-			const id = c.req.param("id");
-			if (!id) {
-				return ResponseFactory.success(c, { error: "App ID is required" }, 400);
-			}
-
-			const app = await getDynamicAppById(id);
-
-			if (!app) {
-				return ResponseFactory.success(c, { error: "App not found" }, 404);
-			}
-
-			return ResponseFactory.success(c, app);
-		})(raw),
+		return app;
+	},
 });
 
 addRoute(dynamicApps, "post", "/:id/execute", {
 	tags: ["dynamic-apps"],
 	summary: "Execute dynamic app",
 	description: "Executes a dynamic app with the provided form data",
+	auth: true,
+	paramSchema: dynamicAppParamsSchema,
+	bodySchema: dynamicAppExecutionBodySchema,
 	responses: {
 		200: {
 			description: "App execution result",
@@ -137,73 +119,31 @@ addRoute(dynamicApps, "post", "/:id/execute", {
 		404: { description: "App not found", schema: dynamicAppErrorResponseSchema },
 		500: { description: "Server error", schema: dynamicAppErrorResponseSchema },
 	},
-	handler: async ({ raw }) =>
-		(async (c: Context) => {
-			const id = c.req.param("id");
-			if (!id) {
-				return ResponseFactory.success(c, { error: "App ID is required" }, 400);
-			}
+	handler: async ({ body, params, raw, serviceContext, user }) => {
+		const requestUrl = new URL(raw.req.url);
+		const req: IRequest = {
+			app_url: `${requestUrl.protocol}//${requestUrl.host}`,
+			env: serviceContext.env,
+			request: {
+				completion_id: generateId(),
+				input: "dynamic-app-execution",
+				date: new Date().toISOString(),
+				platform: "dynamic-apps",
+			},
+			user,
+			context: serviceContext,
+		};
 
-			const user = c.get("user");
-
-			if (!user?.id) {
-				return ResponseFactory.success(
-					c,
-					{
-						response: {
-							status: "error",
-							message: "User not authenticated",
-						},
-					},
-					401,
-				);
-			}
-
-			const formData = await c.req.json();
-
-			try {
-				const app = await getDynamicAppById(id);
-
-				if (!app) {
-					return ResponseFactory.success(c, { error: "App not found" }, 404);
-				}
-
-				const url = new URL(c.req.url);
-				const host = url.host;
-
-				const req: IRequest = {
-					app_url: `https://${host}`,
-					env: c.env,
-					request: {
-						completion_id: generateId(),
-						input: "dynamic-app-execution",
-						date: new Date().toISOString(),
-						platform: "dynamic-apps",
-					},
-					user,
-					context: getServiceContext(c),
-				};
-
-				const result = await executeDynamicApp(id, formData, req);
-				return ResponseFactory.success(c, result);
-			} catch (error) {
-				logger.error(`Error executing app ${id}:`, { error });
-				return ResponseFactory.success(
-					c,
-					{
-						error: "Failed to execute app",
-						message: error instanceof Error ? error.message : "Unknown error",
-					},
-					500,
-				);
-			}
-		})(raw),
+		return executeDynamicApp(params.id, body, req);
+	},
 });
 
 addRoute(dynamicApps, "get", "/responses/:responseId", {
 	tags: ["dynamic-apps"],
 	summary: "Get stored dynamic-app response",
 	description: "Retrieve a stored dynamic-app response by its `id` (response_id)",
+	auth: true,
+	paramSchema: dynamicAppResponseParamsSchema,
 	responses: {
 		200: {
 			description: "Stored dynamic-app response",
@@ -216,19 +156,14 @@ addRoute(dynamicApps, "get", "/responses/:responseId", {
 		},
 		404: { description: "Response not found", schema: dynamicAppErrorResponseSchema },
 	},
-	handler: async ({ raw }) =>
-		(async (c: Context) => {
-			const user = c.get("user") as IUser;
-			const responseId = c.req.param("responseId");
-			if (!responseId) {
-				return ResponseFactory.success(c, { error: "responseId is required" }, 400);
-			}
-			const data = await getDynamicAppResponseById(c.env as IEnv, user.id, responseId);
-			if (!data) {
-				return ResponseFactory.success(c, { error: "Response not found" }, 404);
-			}
-			return ResponseFactory.success(c, { response: data });
-		})(raw),
+	handler: async ({ params, serviceContext, user }) => {
+		const data = await getDynamicAppResponseById(serviceContext, user.id, params.responseId);
+		if (!data) {
+			throw new AssistantError("Response not found", ErrorType.NOT_FOUND, 404);
+		}
+
+		return { response: data };
+	},
 });
 
 export default dynamicApps;

--- a/apps/api/src/services/assets.ts
+++ b/apps/api/src/services/assets.ts
@@ -1,0 +1,32 @@
+import type { ServiceContext } from "~/lib/context/serviceContext";
+import { readAsset } from "~/lib/storage/read-asset";
+
+export interface AssetResponsePayload {
+	body: ArrayBuffer;
+	headers: Headers;
+}
+
+export async function getAssetResponsePayload(params: {
+	context: ServiceContext;
+	assetId: string;
+}): Promise<AssetResponsePayload> {
+	const { context, assetId } = params;
+	const asset = await readAsset({
+		context,
+		assetId,
+		userId: context.user?.id,
+	});
+
+	const headers = new Headers();
+	headers.set("content-type", asset.asset.mime_type);
+	headers.set("cache-control", "private, no-store");
+	headers.set("cross-origin-resource-policy", "cross-origin");
+	if (asset.asset.filename) {
+		headers.set("content-disposition", `inline; filename="${asset.asset.filename}"`);
+	}
+
+	return {
+		body: await asset.object.arrayBuffer(),
+		headers,
+	};
+}

--- a/apps/api/src/services/dynamic-apps/__test__/index.test.ts
+++ b/apps/api/src/services/dynamic-apps/__test__/index.test.ts
@@ -2,17 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AppSchema } from "~/types/app-schema";
 import type { IRequest } from "~/types";
-import { DynamicAppResponseRepository } from "~/repositories/DynamicAppResponseRepository";
 import { executeDynamicApp, registerDynamicApp } from "../index";
 
 vi.mock("~/lib/conversationManager", () => ({
 	ConversationManager: {
-		getInstance: vi.fn(),
-	},
-}));
-
-vi.mock("~/lib/database", () => ({
-	Database: {
 		getInstance: vi.fn(),
 	},
 }));
@@ -46,14 +39,28 @@ const baseApp: Omit<AppSchema, "id"> = {
 	},
 };
 
+const dynamicAppResponseRepository = {
+	createResponse: vi.fn(),
+	updateResponseData: vi.fn(),
+};
+
 function createRequest(overrides: Partial<IRequest> = {}): IRequest {
+	const env = {
+		DB: {},
+		CACHE: null,
+	} as any;
+
 	return {
 		app_url: "https://app.example.com",
-		context: {} as any,
-		env: {
-			DB: {},
-			CACHE: null,
+		context: {
+			database: {},
+			env,
+			repositories: {
+				dynamicAppResponses: dynamicAppResponseRepository,
+			},
+			requestCache: new Map(),
 		} as any,
+		env,
 		request: {
 			completion_id: "completion-123",
 		} as any,
@@ -82,10 +89,10 @@ describe("executeDynamicApp", () => {
 	beforeEach(async () => {
 		vi.clearAllMocks();
 
-		const { ConversationManager } = await import("~/lib/conversationManager");
-		const { Database } = await import("~/lib/database");
+		dynamicAppResponseRepository.createResponse.mockReset();
+		dynamicAppResponseRepository.updateResponseData.mockReset();
 
-		vi.mocked(Database.getInstance).mockReturnValue({} as any);
+		const { ConversationManager } = await import("~/lib/conversationManager");
 		vi.mocked(ConversationManager.getInstance).mockReturnValue({} as any);
 	});
 
@@ -107,14 +114,11 @@ describe("executeDynamicApp", () => {
 
 		vi.mocked(handleFunctions).mockResolvedValue(functionResult as any);
 
-		const createResponseSpy = vi
-			.spyOn(DynamicAppResponseRepository.prototype, "createResponse")
-			.mockResolvedValue({
-				id: "response-123",
-			} as any);
-		const updateResponseDataSpy = vi
-			.spyOn(DynamicAppResponseRepository.prototype, "updateResponseData")
-			.mockResolvedValue();
+		const createResponseSpy = dynamicAppResponseRepository.createResponse.mockResolvedValue({
+			id: "response-123",
+		} as any);
+		const updateResponseDataSpy =
+			dynamicAppResponseRepository.updateResponseData.mockResolvedValue(undefined);
 
 		const result = await executeDynamicApp(appId, formData, createRequest());
 
@@ -181,11 +185,8 @@ describe("executeDynamicApp", () => {
 
 		vi.mocked(handleFunctions).mockResolvedValue(functionResult as any);
 
-		const createResponseSpy = vi.spyOn(DynamicAppResponseRepository.prototype, "createResponse");
-		const updateResponseDataSpy = vi.spyOn(
-			DynamicAppResponseRepository.prototype,
-			"updateResponseData",
-		);
+		const createResponseSpy = dynamicAppResponseRepository.createResponse;
+		const updateResponseDataSpy = dynamicAppResponseRepository.updateResponseData;
 
 		const result = await executeDynamicApp(
 			appId,

--- a/apps/api/src/services/dynamic-apps/index.ts
+++ b/apps/api/src/services/dynamic-apps/index.ts
@@ -1,11 +1,10 @@
 import { ConversationManager } from "~/lib/conversationManager";
 import { getDynamicAppFormErrors } from "@assistant/schemas";
-import { Database } from "~/lib/database";
-import { DynamicAppResponseRepository } from "~/repositories/DynamicAppResponseRepository";
 import { getFeaturedApps, type FeaturedAppDefinition } from "~/services/dynamic-apps/config";
 import { handleFunctions } from "~/services/functions";
 import type { AppSchema } from "~/types/app-schema";
-import type { IRequest, IEnv } from "~/types";
+import type { IRequest } from "~/types";
+import type { ServiceContext } from "~/lib/context/serviceContext";
 import type { AppData } from "~/repositories/AppDataRepository";
 import { AssistantError, ErrorType } from "~/utils/errors";
 import { getLogger } from "~/utils/logger";
@@ -107,6 +106,17 @@ export const getDynamicAppById = async (id: string): Promise<AppSchema | null> =
 	return dynamicApps.get(id) || null;
 };
 
+const getDynamicAppServiceContext = (req: IRequest): ServiceContext => {
+	if (!req.context) {
+		throw new AssistantError(
+			"Dynamic app execution requires a service context",
+			ErrorType.CONFIGURATION_ERROR,
+		);
+	}
+
+	return req.context;
+};
+
 /**
  * Execute a dynamic app with the provided form data
  * @param id The app ID
@@ -128,15 +138,16 @@ export const executeDynamicApp = async (
 	validateFormData(app, formData);
 
 	const { env, user } = req;
-
-	const database = Database.getInstance(env);
+	const serviceContext = getDynamicAppServiceContext(req);
 
 	const conversationManager = ConversationManager.getInstance({
-		database,
+		database: serviceContext.database,
 		user,
 		store: !!user?.id,
 		platform: "dynamic-apps",
 		env,
+		requestCache: serviceContext.requestCache,
+		repositories: serviceContext.repositories,
 	});
 
 	try {
@@ -159,7 +170,7 @@ export const executeDynamicApp = async (
 					(resultData?.asyncInvocation?.id as string | undefined);
 
 				const saved = await createDynamicAppResponse(
-					env,
+					serviceContext,
 					user.id,
 					id,
 					{
@@ -188,8 +199,7 @@ export const executeDynamicApp = async (
 
 					functionResult = augmentedResult;
 
-					const repo = new DynamicAppResponseRepository(env);
-					await repo.updateResponseData(saved.id, {
+					await serviceContext.repositories.dynamicAppResponses.updateResponseData(saved.id, {
 						formData,
 						result: augmentedResult,
 					});
@@ -240,14 +250,13 @@ const validateFormData = (app: AppSchema, formData: Record<string, any>): void =
  * @returns The created response
  */
 export const createDynamicAppResponse = async (
-	env: IEnv,
+	context: ServiceContext,
 	userId: number,
 	appId: string,
 	payload: Record<string, any>,
 	itemId?: string,
 ): Promise<AppData> => {
-	const repo = new DynamicAppResponseRepository(env);
-	return repo.createResponse(userId, appId, payload, itemId);
+	return context.repositories.dynamicAppResponses.createResponse(userId, appId, payload, itemId);
 };
 
 /**
@@ -258,12 +267,11 @@ export const createDynamicAppResponse = async (
  * @returns The response data or null if not found
  */
 export const getDynamicAppResponseById = async (
-	env: IEnv,
+	context: ServiceContext,
 	userId: number,
 	responseId: string,
 ): Promise<AppData | null> => {
-	const repo = new DynamicAppResponseRepository(env);
-	return repo.getResponseByIdForUser(responseId, userId);
+	return context.repositories.dynamicAppResponses.getResponseByIdForUser(responseId, userId);
 };
 
 /**
@@ -274,10 +282,9 @@ export const getDynamicAppResponseById = async (
  * @returns Array of response data
  */
 export const listDynamicAppResponsesForUser = async (
-	env: IEnv,
+	context: ServiceContext,
 	userId: number,
 	appId?: string,
 ): Promise<AppData[]> => {
-	const repo = new DynamicAppResponseRepository(env);
-	return repo.listResponsesForUser(userId, appId);
+	return context.repositories.dynamicAppResponses.listResponsesForUser(userId, appId);
 };


### PR DESCRIPTION
### Motivation
- Separate routing concerns from business logic so routes only validate and route, and services own core operations and standardized outputs.
- Normalize usage of the shared `ServiceContext` so services reuse the same database/repositories/request cache rather than constructing their own.
- Make route handlers consistent with `addRoute` handler context and OpenAPI metadata to simplify validation and documentation.

### Description
- Added a new `assets` service (`apps/api/src/services/assets.ts`) that performs asset retrieval and header/Response assembly and returns a typed `AssetResponsePayload` instead of doing this work in the route. 
- Reworked the assets route (`apps/api/src/routes/assets.ts`) to use `addRoute`, a `paramSchema`, OpenAPI responses, and to call `getAssetResponsePayload` with the provided `serviceContext` and `params`.
- Refactored dynamic-apps routes (`apps/api/src/routes/dynamic-apps.ts`) to use `addRoute` handler context (`params`, `body`, `query`, `serviceContext`, `user`), add `auth: true`, and apply `paramSchema`/`bodySchema` for validation instead of manually re-reading `raw` Hono context and building responses.
- Updated dynamic-apps service (`apps/api/src/services/dynamic-apps/index.ts`) to require and resolve a `ServiceContext` for execution via `getDynamicAppServiceContext`, reuse `serviceContext.database`, `serviceContext.repositories` and `serviceContext.requestCache`, and to use `context.repositories.dynamicAppResponses` for persistence helpers (`createDynamicAppResponse`, `getDynamicAppResponseById`, `listDynamicAppResponsesForUser`).
- Adjusted tests to mock the shared service-context repository shape and updated expectations in `apps/api/src/services/dynamic-apps/__test__/index.test.ts` and `apps/api/src/routes/__test__/assets.test.ts` to reflect the new context-passing pattern.

### Testing
- Built the `@assistant/schemas` package and ran type checking with `pnpm --filter @assistant/schemas build && pnpm --filter @assistant/api typecheck`, which succeeded after updating the code.
- Ran unit tests `vitest` for the updated areas with `pnpm --filter @assistant/api exec vitest run src/services/dynamic-apps/__test__/index.test.ts` and `pnpm --filter @assistant/api exec vitest run src/routes/__test__/assets.test.ts`, both tests passed.
- Executed the monorepo checks `pnpm --filter @assistant/api check` (lint/format), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2136140a0c832aa09f352a944b6081)