### PR TITLE
Fix iOS chat stream placeholder handling

### DIFF
--- a/apps/mobile/ios/Polychat/Services/ConversationManager.swift
+++ b/apps/mobile/ios/Polychat/Services/ConversationManager.swift
@@ -172,6 +172,9 @@ class ConversationManager: ObservableObject {
         currentConversation = conversation
         updateConversationInArray(conversation)
 
+        var finalMessageId = assistantMessageId
+        var didReceiveStreamEvent = false
+
         do {
             let currentSelectedModelId = await MainActor.run { modelsStore?.selectedModelId }
             let modelToUse = conversation.modelId ??
@@ -180,22 +183,25 @@ class ConversationManager: ObservableObject {
                            "mistral-small"
             let providerToUse = modelsStore?.model(withId: modelToUse)?.provider
 
-            guard let stream = apiClient?.streamChatCompletion(
+            guard let apiClient else {
+                throw NSError(domain: "com.polychat.app", code: 1,
+                             userInfo: [NSLocalizedDescriptionKey: "API client not configured"])
+            }
+
+            let stream = apiClient.streamChatCompletion(
                 messages: Array(conversation.messages.dropLast()),
                 modelId: modelToUse,
                 provider: providerToUse,
                 completionId: conversation.id,
                 settings: settings
-            ) else {
-                return
-            }
+            )
 
             var streamedContent = ""
             var streamedReasoning = ""
-            var finalMessageId = assistantMessageId
             var responseModelId = modelToUse
 
             for try await event in stream {
+                didReceiveStreamEvent = true
                 switch event {
                 case .content(let delta):
                     streamedContent += delta
@@ -203,7 +209,8 @@ class ConversationManager: ObservableObject {
                         conversationId: conversation.id,
                         messageId: finalMessageId,
                         content: streamedContent,
-                        modelId: responseModelId
+                        modelId: responseModelId,
+                        fallbackMessageId: assistantMessageId
                     )
                 case .reasoning(let delta):
                     streamedReasoning += delta
@@ -212,7 +219,8 @@ class ConversationManager: ObservableObject {
                             conversationId: conversation.id,
                             messageId: finalMessageId,
                             content: "<think>\n\(streamedReasoning)",
-                            modelId: responseModelId
+                            modelId: responseModelId,
+                            fallbackMessageId: assistantMessageId
                         )
                     }
                 case .state:
@@ -232,7 +240,8 @@ class ConversationManager: ObservableObject {
                         messageId: finalMessageId,
                         content: streamedContent,
                         modelId: responseModelId,
-                        metadata: metadata
+                        metadata: metadata,
+                        fallbackMessageId: assistantMessageId
                     )
                 case .done:
                     break
@@ -245,7 +254,8 @@ class ConversationManager: ObservableObject {
                     conversationId: conversation.id,
                     messageId: finalMessageId,
                     content: streamedContent,
-                    modelId: responseModelId
+                    modelId: responseModelId,
+                    fallbackMessageId: assistantMessageId
                 )
             }
 
@@ -255,9 +265,11 @@ class ConversationManager: ObservableObject {
         } catch {
             updateAssistantMessage(
                 conversationId: conversation.id,
-                messageId: assistantMessageId,
+                messageId: finalMessageId,
                 content: "Error: \(error.localizedDescription)",
-                modelId: conversation.modelId
+                modelId: conversation.modelId,
+                fallbackMessageId: assistantMessageId,
+                markLoadedFromAPI: didReceiveStreamEvent
             )
         }
     }
@@ -267,40 +279,44 @@ class ConversationManager: ObservableObject {
         messageId: String,
         content: String,
         modelId: String?,
-        metadata: ChatStreamMetadata? = nil
+        metadata: ChatStreamMetadata? = nil,
+        fallbackMessageId: String? = nil,
+        markLoadedFromAPI: Bool = true
     ) {
         guard let index = conversations.firstIndex(where: { $0.id == conversationId }) else {
             return
         }
 
         var conversation = conversations[index]
-        let messageIndex = conversation.messages.lastIndex { message in
-            message.id == messageId
-        } ?? conversation.messages.lastIndex { message in
-            message.role == "assistant"
-        }
+        let messageIndex = assistantMessageIndex(
+            in: conversation,
+            messageId: messageId,
+            fallbackMessageId: fallbackMessageId
+        )
 
         guard let messageIndex else {
             return
         }
 
+        let existingMessage = conversation.messages[messageIndex]
+        let created = metadata?.created ?? existingMessage.created
         conversation.messages[messageIndex] = ChatMessage(
             id: messageId,
             role: "assistant",
             content: content,
-            model: modelId,
-            parts: metadata?.parts,
-            reasoning: metadata?.reasoning,
-            citations: metadata?.citations,
-            data: metadata?.data,
-            name: metadata?.name,
-            status: metadata?.status,
-            logId: metadata?.logId,
-            created: metadata?.created,
-            timestamp: metadata?.created
+            model: modelId ?? existingMessage.model,
+            parts: metadata?.parts ?? existingMessage.parts,
+            reasoning: metadata?.reasoning ?? existingMessage.reasoning,
+            citations: metadata?.citations ?? existingMessage.citations,
+            data: metadata?.data ?? existingMessage.data,
+            name: metadata?.name ?? existingMessage.name,
+            status: metadata?.status ?? existingMessage.status,
+            logId: metadata?.logId ?? existingMessage.logId,
+            created: created,
+            timestamp: created ?? existingMessage.timestamp
         )
-        conversation.isLoadedFromAPI = true
-        conversation.modelId = modelId
+        conversation.isLoadedFromAPI = conversation.isLoadedFromAPI || markLoadedFromAPI
+        conversation.modelId = modelId ?? conversation.modelId
         conversation.lastMessageAt = Date()
         conversation.messageCount = conversation.messages.count
         conversations[index] = conversation
@@ -310,6 +326,25 @@ class ConversationManager: ObservableObject {
         }
     }
     
+    private func assistantMessageIndex(
+        in conversation: Conversation,
+        messageId: String,
+        fallbackMessageId: String?
+    ) -> Int? {
+        if let index = conversation.messages.lastIndex(where: { $0.id == messageId }) {
+            return index
+        }
+
+        if let fallbackMessageId,
+           let index = conversation.messages.lastIndex(where: { $0.id == fallbackMessageId }) {
+            return index
+        }
+
+        return fallbackMessageId == nil
+            ? conversation.messages.lastIndex(where: { $0.role == "assistant" })
+            : nil
+    }
+
     private func updateConversationInArray(_ conversation: Conversation) {
         if let index = conversations.firstIndex(where: { $0.id == conversation.id }) {
             conversations[index] = conversation

--- a/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
+++ b/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
@@ -65,14 +65,15 @@ struct ServiceStoreTests {
                 content: "Hello there",
                 model: "gpt-4o",
                 parts: nil,
-                reasoning: nil,
-                citations: nil,
+                reasoning: ChatReasoning(collapsed: true, content: "Reasoned"),
+                citations: [ChatCitation(url: "https://example.com", title: "Example")],
                 data: nil,
                 name: nil,
-                status: nil,
-                logId: nil,
+                status: "complete",
+                logId: "log-1",
                 created: 1_774_000_000
             )),
+            .content("!"),
             .done
         ]
 
@@ -92,8 +93,26 @@ struct ServiceStoreTests {
         #expect(apiClient.streamedMessages.map(\.role) == ["user"])
         #expect(manager.currentConversation?.messages.map(\.role) == ["user", "assistant"])
         #expect(manager.currentConversation?.messages.last?.id == "server-message")
-        #expect(manager.currentConversation?.messages.last?.textContent == "Hello there")
+        #expect(manager.currentConversation?.messages.last?.textContent == "Hello there!")
         #expect(manager.currentConversation?.messages.last?.model == "gpt-4o")
+        #expect(manager.currentConversation?.messages.last?.reasoning?.content == "Reasoned")
+        #expect(manager.currentConversation?.messages.last?.citations?.first?.url == "https://example.com")
+        #expect(manager.currentConversation?.messages.last?.status == "complete")
+        #expect(manager.currentConversation?.messages.last?.logId == "log-1")
+        #expect(manager.currentConversation?.messages.last?.created == 1_774_000_000)
         #expect(manager.currentConversation?.title == "Generated title")
+    }
+
+    @MainActor
+    @Test func conversationManagerReplacesLoadingMessageWhenAPIClientIsMissing() async throws {
+        let manager = ConversationManager()
+        _ = manager.startNewConversation()
+
+        try await manager.addMessage(ChatMessage(role: "user", content: "Hi"))
+
+        #expect(manager.currentConversation?.messages.map(\.role) == ["user", "assistant"])
+        #expect(manager.currentConversation?.messages.last?.textContent.contains("API client not configured") == true)
+        #expect(manager.currentConversation?.messages.last?.textContent.hasPrefix("Error:") == true)
+        #expect(manager.currentConversation?.isLoadedFromAPI == false)
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent silent no-op when the `ConversationAPIClient` is missing and ensure the UI shows an inline assistant error instead of a forever-empty loading bubble. 
- Make streamed assistant updates resilient to server-provided message IDs so metadata and later content deltas update the correct assistant bubble. 
- Preserve assistant metadata (reasoning, citations, status, timestamps) when subsequent content deltas arrive so we don't overwrite useful information. 
- Add tests that assert metadata is preserved and that missing API client behavior replaces the placeholder message.

### Description
- Replace the silent early-return guard around `apiClient?.streamChatCompletion` with a check that throws a descriptive error and replaces the placeholder assistant message on failure using `didReceiveStreamEvent` and `markLoadedFromAPI` flags. 
- Track the placeholder assistant message separately from server message IDs by introducing `finalMessageId` and a `fallbackMessageId` parameter passed to `updateAssistantMessage` so server metadata can rename the placeholder safely. 
- Update `updateAssistantMessage` to preserve existing assistant message fields and to merge incoming `ChatStreamMetadata` (fields like `parts`, `reasoning`, `citations`, `status`, `logId`, `created`) rather than discarding them, and to only mark `conversation.isLoadedFromAPI` if a stream event actually arrived. 
- Add a helper `assistantMessageIndex(in:messageId:fallbackMessageId:)` to robustly locate the correct assistant message to update. 
- Extend tests in `ServiceStoreTests` to include richer metadata in stream events and to add a new test verifying replacement of the loading message when the API client is missing.

### Testing
- `git diff --check` was run and produced no whitespace/patch issues. 
- `sh scripts/xcodebuild-mobile.sh test` and `pnpm test:mobile` were attempted but are blocked in this environment because Xcode command-line tools / simulator runtime are not available (`xcrun` and `xcodebuild` missing). 
- `swift test` is not applicable in this repository layout (no `Package.swift`). 
- Unit test files were updated (`apps/mobile/ios/PolychatTests/ServiceStoreTests.swift`) to assert the new metadata behavior and error-replacement behavior, but they were not executed here due to the environment limitation above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a246dc836b0832aa23ce46ce42c0e2e)