### PR TITLE
Improve iOS conversation actions

### DIFF
--- a/apps/mobile/ios/Polychat/Services/ConversationManager.swift
+++ b/apps/mobile/ios/Polychat/Services/ConversationManager.swift
@@ -166,9 +166,68 @@ class ConversationManager: ObservableObject {
         currentConversation = conversation
         updateConversationInArray(conversation)
 
+        await generateAssistantResponse(
+            conversationId: conversation.id,
+            requestMessages: conversation.messages,
+            settings: settings,
+            generateTitle: true
+        )
+    }
+
+    func regenerateAssistantMessage(_ messageId: String, settings: ChatSettings? = nil) async {
+        guard var conversation = currentConversation,
+              let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId }) else {
+            error = "Unable to retry: message not found"
+            return
+        }
+
+        let message = conversation.messages[messageIndex]
+        let retryEndIndex: Int
+
+        if message.role == "assistant" {
+            retryEndIndex = messageIndex
+        } else if message.role == "user" {
+            retryEndIndex = messageIndex + 1
+        } else {
+            error = "Only user and assistant messages can be retried"
+            return
+        }
+
+        let requestMessages = Array(conversation.messages.prefix(retryEndIndex))
+        guard requestMessages.contains(where: { $0.role == "user" }) else {
+            error = "Unable to retry without a user message"
+            return
+        }
+
+        conversation.messages = requestMessages
+        conversation.lastMessageAt = Date()
+        conversation.messageCount = requestMessages.count
+        currentConversation = conversation
+        updateConversationInArray(conversation)
+
+        await generateAssistantResponse(
+            conversationId: conversation.id,
+            requestMessages: requestMessages,
+            settings: settings,
+            generateTitle: false
+        )
+    }
+
+    private func generateAssistantResponse(
+        conversationId: String,
+        requestMessages: [ChatMessage],
+        settings: ChatSettings?,
+        generateTitle: Bool
+    ) async {
+        guard var conversation = conversations.first(where: { $0.id == conversationId }) else {
+            return
+        }
+
         let assistantMessageId = UUID().uuidString
         let loadingMessage = ChatMessage(id: assistantMessageId, role: "assistant", content: "")
         conversation.messages.append(loadingMessage)
+        conversation.lastMessageAt = Date()
+        conversation.messageCount = conversation.messages.count
         currentConversation = conversation
         updateConversationInArray(conversation)
 
@@ -189,10 +248,10 @@ class ConversationManager: ObservableObject {
             }
 
             let stream = apiClient.streamChatCompletion(
-                messages: Array(conversation.messages.dropLast()),
+                messages: requestMessages,
                 modelId: modelToUse,
                 provider: providerToUse,
-                completionId: conversation.id,
+                completionId: conversationId,
                 settings: settings
             )
 
@@ -206,7 +265,7 @@ class ConversationManager: ObservableObject {
                 case .content(let delta):
                     streamedContent += delta
                     updateAssistantMessage(
-                        conversationId: conversation.id,
+                        conversationId: conversationId,
                         messageId: finalMessageId,
                         content: streamedContent,
                         modelId: responseModelId,
@@ -216,7 +275,7 @@ class ConversationManager: ObservableObject {
                     streamedReasoning += delta
                     if streamedContent.isEmpty {
                         updateAssistantMessage(
-                            conversationId: conversation.id,
+                            conversationId: conversationId,
                             messageId: finalMessageId,
                             content: "<think>\n\(streamedReasoning)",
                             modelId: responseModelId,
@@ -236,7 +295,7 @@ class ConversationManager: ObservableObject {
                         streamedContent = content
                     }
                     updateAssistantMessage(
-                        conversationId: conversation.id,
+                        conversationId: conversationId,
                         messageId: finalMessageId,
                         content: streamedContent,
                         modelId: responseModelId,
@@ -251,7 +310,7 @@ class ConversationManager: ObservableObject {
             if streamedContent.isEmpty {
                 streamedContent = streamedReasoning.isEmpty ? "No response" : "<think>\n\(streamedReasoning)"
                 updateAssistantMessage(
-                    conversationId: conversation.id,
+                    conversationId: conversationId,
                     messageId: finalMessageId,
                     content: streamedContent,
                     modelId: responseModelId,
@@ -259,12 +318,14 @@ class ConversationManager: ObservableObject {
                 )
             }
 
-            if let updatedConversation = currentConversation, updatedConversation.id == conversation.id {
+            if generateTitle,
+               let updatedConversation = currentConversation,
+               updatedConversation.id == conversationId {
                 await generateTitleIfNeeded(for: updatedConversation)
             }
         } catch {
             updateAssistantMessage(
-                conversationId: conversation.id,
+                conversationId: conversationId,
                 messageId: finalMessageId,
                 content: "Error: \(error.localizedDescription)",
                 modelId: conversation.modelId,

--- a/apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift
+++ b/apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift
@@ -61,6 +61,7 @@ struct MessageBubble: View {
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }
+                            .accessibilityLabel("Retry message")
                         }
 
                         Button(action: copyMessage) {
@@ -68,6 +69,7 @@ struct MessageBubble: View {
                                 .font(.caption)
                                 .foregroundColor(.secondary)
                         }
+                        .accessibilityLabel("Copy message")
                     }
                 }
             }
@@ -139,8 +141,9 @@ struct MessageBubble: View {
     }
 
     private func regenerateMessage() {
-        // TODO: Implement regenerate functionality
-        // This would require modifying ConversationManager to support regeneration
+        Task {
+            await conversationManager.regenerateAssistantMessage(message.id)
+        }
     }
 
     private func copyMessage() {

--- a/apps/mobile/ios/Polychat/Views/ConversationListView.swift
+++ b/apps/mobile/ios/Polychat/Views/ConversationListView.swift
@@ -5,6 +5,9 @@ struct ConversationListView: View {
     @EnvironmentObject var conversationManager: ConversationManager
     @Binding var selectedConversationID: String?
     @State private var searchText = ""
+    @State private var conversationPendingDeletion: Conversation?
+    @State private var conversationPendingRename: Conversation?
+    @State private var renameTitle = ""
     let onShowSettings: () -> Void
 
     init(
@@ -51,9 +54,34 @@ struct ConversationListView: View {
                             .listRowInsets(EdgeInsets(top: 3, leading: 8, bottom: 3, trailing: 8))
                             .listRowBackground(Color.clear)
                             .listRowSeparator(.hidden)
-                        }
-                        .onDelete { offsets in
-                            deleteConversations(from: section.conversations, at: offsets)
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                Button(role: .destructive) {
+                                    conversationPendingDeletion = conversation
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
+                            .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                                Button {
+                                    beginRenaming(conversation)
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
+                                .tint(.blue)
+                            }
+                            .contextMenu {
+                                Button {
+                                    beginRenaming(conversation)
+                                } label: {
+                                    Label("Rename", systemImage: "pencil")
+                                }
+
+                                Button(role: .destructive) {
+                                    conversationPendingDeletion = conversation
+                                } label: {
+                                    Label("Delete", systemImage: "trash")
+                                }
+                            }
                         }
                     }
                 }
@@ -105,6 +133,34 @@ struct ConversationListView: View {
                 }
             }
         }
+        .alert("Rename Conversation", isPresented: renameAlertBinding) {
+            TextField("Title", text: $renameTitle)
+            Button("Cancel", role: .cancel) {
+                conversationPendingRename = nil
+                renameTitle = ""
+            }
+            Button("Save") {
+                saveRename()
+            }
+            .disabled(renameTitle.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        } message: {
+            Text("Update the title shown in your conversation list.")
+        }
+        .confirmationDialog(
+            "Delete Conversation",
+            isPresented: deleteDialogBinding,
+            titleVisibility: .visible,
+            presenting: conversationPendingDeletion
+        ) { conversation in
+            Button("Delete \"\(conversation.title)\"", role: .destructive) {
+                deleteConversation(conversation)
+            }
+            Button("Cancel", role: .cancel) {
+                conversationPendingDeletion = nil
+            }
+        } message: { _ in
+            Text("This action cannot be undone.")
+        }
         .alert("Error", isPresented: .constant(conversationManager.error != nil)) {
             Button("OK") {
                 conversationManager.error = nil
@@ -121,11 +177,58 @@ struct ConversationListView: View {
         selectedConversationID = conversation.id
     }
 
-    private func deleteConversations(from conversations: [Conversation], at offsets: IndexSet) {
+    private var renameAlertBinding: Binding<Bool> {
+        Binding(
+            get: { conversationPendingRename != nil },
+            set: { isPresented in
+                if !isPresented {
+                    conversationPendingRename = nil
+                    renameTitle = ""
+                }
+            }
+        )
+    }
+
+    private var deleteDialogBinding: Binding<Bool> {
+        Binding(
+            get: { conversationPendingDeletion != nil },
+            set: { isPresented in
+                if !isPresented {
+                    conversationPendingDeletion = nil
+                }
+            }
+        )
+    }
+
+    private func beginRenaming(_ conversation: Conversation) {
+        conversationPendingRename = conversation
+        renameTitle = conversation.title
+    }
+
+    private func saveRename() {
+        guard let conversation = conversationPendingRename else {
+            return
+        }
+
+        let trimmedTitle = renameTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else {
+            return
+        }
+
+        conversationPendingRename = nil
+        renameTitle = ""
+
         Task {
-            for index in offsets {
-                let conversation = conversations[index]
-                await conversationManager.deleteConversation(conversation)
+            await conversationManager.updateConversationTitle(conversation.id, title: trimmedTitle)
+        }
+    }
+
+    private func deleteConversation(_ conversation: Conversation) {
+        conversationPendingDeletion = nil
+        Task {
+            await conversationManager.deleteConversation(conversation)
+            if selectedConversationID == conversation.id {
+                selectedConversationID = conversationManager.conversations.first?.id
             }
         }
     }

--- a/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
+++ b/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
@@ -115,4 +115,51 @@ struct ServiceStoreTests {
         #expect(manager.currentConversation?.messages.last?.textContent.hasPrefix("Error:") == true)
         #expect(manager.currentConversation?.isLoadedFromAPI == false)
     }
+
+    @MainActor
+    @Test func conversationManagerRegeneratesAssistantMessageFromPriorContext() async throws {
+        let apiClient = ConversationAPIClientStub()
+        apiClient.streamEvents = [
+            .content("Updated answer"),
+            .done
+        ]
+
+        let manager = ConversationManager()
+        manager.configure(apiClient: apiClient)
+        let conversation = manager.startNewConversation()
+        manager.currentConversation?.messages = [
+            ChatMessage(id: "user-1", role: "user", content: "Question"),
+            ChatMessage(id: "assistant-1", role: "assistant", content: "Old answer"),
+            ChatMessage(id: "user-2", role: "user", content: "Follow up")
+        ]
+        if let currentConversation = manager.currentConversation {
+            manager.conversations = [currentConversation]
+        }
+
+        await manager.regenerateAssistantMessage("assistant-1")
+
+        #expect(apiClient.streamCallCount == 1)
+        #expect(apiClient.streamedCompletionId == conversation.id)
+        #expect(apiClient.streamedMessages.map(\.id) == ["user-1"])
+        #expect(manager.currentConversation?.messages.map(\.role) == ["user", "assistant"])
+        #expect(manager.currentConversation?.messages.last?.textContent == "Updated answer")
+        #expect(manager.currentConversation?.title == "New Conversation")
+    }
+
+    @MainActor
+    @Test func conversationManagerPersistsRenamedLoadedConversation() async throws {
+        let apiClient = ConversationAPIClientStub()
+        let manager = ConversationManager()
+        manager.configure(apiClient: apiClient)
+        let conversation = makeConversation(id: "conversation-1", title: "Old", isLoadedFromAPI: true)
+        manager.conversations = [conversation]
+        manager.currentConversation = conversation
+
+        await manager.updateConversationTitle("conversation-1", title: "Renamed")
+
+        #expect(manager.currentConversation?.title == "Renamed")
+        #expect(manager.conversations.first?.title == "Renamed")
+        #expect(apiClient.updatedConversationTitles.first?.id == "conversation-1")
+        #expect(apiClient.updatedConversationTitles.first?.title == "Renamed")
+    }
 }

--- a/apps/mobile/ios/PolychatTests/TestSupport.swift
+++ b/apps/mobile/ios/PolychatTests/TestSupport.swift
@@ -93,6 +93,9 @@ final class ConversationAPIClientStub: ConversationAPIClient {
     var streamedMessages: [ChatMessage] = []
     var streamedModelId: String?
     var streamedCompletionId: String?
+    var streamCallCount = 0
+    var updatedConversationTitles: [(id: String, title: String)] = []
+    var deletedConversationIds: [String] = []
     var generatedTitle = "Generated title"
 
     func fetchConversations(limit: Int, page: Int, includeArchived: Bool) async throws -> ConversationListResponse {
@@ -110,6 +113,7 @@ final class ConversationAPIClientStub: ConversationAPIClient {
         completionId: String?,
         settings: ChatSettings?
     ) -> AsyncThrowingStream<ChatStreamEvent, Error> {
+        streamCallCount += 1
         streamedMessages = messages
         streamedModelId = modelId
         streamedCompletionId = completionId
@@ -126,7 +130,11 @@ final class ConversationAPIClientStub: ConversationAPIClient {
         TitleGenerationResponse(title: generatedTitle)
     }
 
-    func updateConversation(id: String, title: String) async throws {}
+    func updateConversation(id: String, title: String) async throws {
+        updatedConversationTitles.append((id: id, title: title))
+    }
 
-    func deleteConversation(id: String) async throws {}
+    func deleteConversation(id: String) async throws {
+        deletedConversationIds.append(id)
+    }
 }


### PR DESCRIPTION
### Motivation
- Bring web conversation features to the iOS client: allow retry/regenerate of assistant responses, safer rename/delete UX, and parity for message actions.
- Make assistant retry a first-class flow that reuses prior user context and streams a replacement assistant response.
- Improve accessibility and surface-level affordances (swipe, context menu, dialogs) so conversation management is less error-prone on mobile.

### Description
- Added a retry/regenerate flow to `ConversationManager`: new `regenerateAssistantMessage(_:settings:)` and `generateAssistantResponse(...)` helpers that trim conversation context, insert a loading assistant message, and stream a replacement using the existing streaming handler (`streamChatCompletion`).
- Updated `addMessage(_:,settings:)` to reuse the new `generateAssistantResponse` path so normal sends and retries share logic and metadata handling.
- Wired the chat bubble retry control to the manager and added accessibility labels: `regenerateMessage()` now calls `conversationManager.regenerateAssistantMessage(message.id)` and the retry/copy buttons expose `accessibilityLabel`s (`"Retry message"`, `"Copy message"`).
- Enhanced `ConversationListView` with swipe actions, context menu, a rename text-field alert, and a destructive delete confirmation dialog; added helpers `beginRenaming`, `saveRename`, `deleteConversation`, and `renameAlertBinding`/`deleteDialogBinding` to drive the UI and call `conversationManager.updateConversationTitle` and `conversationManager.deleteConversation`.
- Tests and test stubs updated: `ConversationAPIClientStub` in test support now tracks `streamCallCount`, `updatedConversationTitles`, and `deletedConversationIds`; added tests `conversationManagerRegeneratesAssistantMessageFromPriorContext` and `conversationManagerPersistsRenamedLoadedConversation` to validate retry streaming and persisted rename behavior.

### Testing
- Ran a parse of the iOS sources with `swiftc -parse $(rg --files apps/mobile/ios -g '*.swift')`, which completed without parse errors.
- Attempted to run the full iOS test script `./scripts/xcodebuild-mobile.sh test`, but it could not run in this environment because `xcrun`/`xcodebuild` and an iOS Simulator runtime are not available. Automated iOS test execution was therefore blocked.
- New unit tests were added but not executed in this environment: `conversationManagerRegeneratesAssistantMessageFromPriorContext` and `conversationManagerPersistsRenamedLoadedConversation` (they rely on the updated `ConversationAPIClientStub`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2490c64ac8832a8663acdee1a79ccb)