### PR TITLE
Add assistant recipes setup flow (API, web, iOS)

### DIFF
--- a/apps/api/src/routes/apps/index.ts
+++ b/apps/api/src/routes/apps/index.ts
@@ -20,6 +20,7 @@ import podcasts from "./podcasts";
 import retrieval from "./retrieval";
 import shared from "./shared";
 import replicate from "./replicate";
+import recipes from "./recipes";
 import canvas from "./canvas";
 import strudel from "./strudel";
 import sandbox from "./sandbox";
@@ -32,6 +33,8 @@ app.use("/*", (c, next) => {
 	routeLogger.info(`Processing apps route: ${c.req.path}`);
 	return next();
 });
+
+app.route("/recipes", recipes);
 
 app.use("/*", requireAuth);
 

--- a/apps/api/src/routes/apps/recipes.ts
+++ b/apps/api/src/routes/apps/recipes.ts
@@ -1,0 +1,93 @@
+import { Hono } from "hono";
+import z from "zod/v4";
+
+import {
+	assistantRecipeInstallRequestSchema,
+	assistantRecipeInstallResponseSchema,
+	assistantRecipesResponseSchema,
+	errorResponseSchema,
+} from "@assistant/schemas";
+import { addRoute } from "~/lib/http/routeBuilder";
+import { ResponseFactory } from "~/lib/http/ResponseFactory";
+import {
+	assistantRecipes,
+	createRecipeMessageUrl,
+	getRecipeById,
+	recipeCategories,
+	recipeFilters,
+} from "~/services/apps/recipes";
+
+const app = new Hono();
+
+addRoute(app, "get", "/", {
+	tags: ["apps"],
+	summary: "List assistant recipes",
+	description:
+		"Returns one-tap assistant setups for integrations and automations that can be started from web, iOS, or messaging surfaces.",
+	responses: {
+		200: { description: "Assistant recipes", schema: assistantRecipesResponseSchema },
+	},
+	handler: async () => ({
+		recipes: assistantRecipes,
+		categories: recipeCategories,
+		filters: recipeFilters,
+	}),
+});
+
+addRoute(app, "get", "/:id", {
+	tags: ["apps"],
+	summary: "Get an assistant recipe",
+	paramSchema: z.object({ id: z.string() }),
+	responses: {
+		200: {
+			description: "Assistant recipe",
+			schema: assistantRecipesResponseSchema.shape.recipes.element,
+		},
+		404: { description: "Recipe not found", schema: errorResponseSchema },
+	},
+	handler: async ({ raw, params }) => {
+		const recipe = getRecipeById(params.id);
+		if (!recipe) {
+			return ResponseFactory.error(raw, "Recipe not found", 404);
+		}
+
+		return recipe;
+	},
+});
+
+addRoute(app, "post", "/:id/install", {
+	tags: ["apps"],
+	summary: "Start recipe setup",
+	description:
+		"Creates the setup payload a client can use to open a chat with the assistant and complete integration configuration conversationally.",
+	paramSchema: z.object({ id: z.string() }),
+	bodySchema: assistantRecipeInstallRequestSchema,
+	responses: {
+		200: { description: "Recipe setup payload", schema: assistantRecipeInstallResponseSchema },
+		404: { description: "Recipe not found", schema: errorResponseSchema },
+	},
+	handler: async ({ raw, params, body }) => {
+		const recipe = getRecipeById(params.id);
+		if (!recipe) {
+			return ResponseFactory.error(raw, "Recipe not found", 404);
+		}
+
+		const channelCopy =
+			body.channel === "ios" ? "on iOS" : body.channel === "sms" ? "over text" : "in web chat";
+		const conversationStarter = `${recipe.setupPrompt}\n\nI am starting this setup ${channelCopy}. Walk me through the required connections, confirm privacy boundaries, and ask before taking actions that send messages or change external systems.`;
+
+		return {
+			recipe,
+			conversationStarter,
+			messageUrl: createRecipeMessageUrl(conversationStarter),
+			checklist: [
+				"Confirm the goal and preferred notification channel",
+				"Connect or verify required integrations",
+				"Choose triggers, schedule, and approval rules",
+				"Send a test run before enabling automation",
+			],
+		};
+	},
+});
+
+export default app;

--- a/apps/api/src/services/apps/recipes.ts
+++ b/apps/api/src/services/apps/recipes.ts
@@ -1,0 +1,235 @@
+import type { AssistantRecipe, RecipeCategory, RecipeKind } from "@assistant/schemas";
+
+export const recipeCategories: RecipeCategory[] = [
+	"Calendar",
+	"Community",
+	"Developer",
+	"Email",
+	"Finance",
+	"Health",
+	"Home",
+	"Productivity",
+	"Scheduling",
+	"Shopping",
+	"Students",
+	"To-dos",
+	"Travel",
+];
+
+export const recipeFilters: RecipeKind[] = ["automate", "integrate"];
+
+export const assistantRecipes: AssistantRecipe[] = [
+	{
+		id: "inbox-chief-of-staff",
+		title: "Inbox chief of staff",
+		summary: "Summarise important email, draft replies, and text you when something needs action.",
+		description:
+			"Connect Gmail or Outlook and let your assistant triage urgent threads, prepare replies in your voice, and keep your inbox from becoming another app you have to babysit.",
+		kind: "automate",
+		category: "Email",
+		featured: true,
+		estimatedSetupMinutes: 3,
+		integrations: [
+			{
+				id: "gmail",
+				name: "Gmail",
+				description: "Search, label, draft, and send email once connected.",
+				requiresConnection: true,
+			},
+			{
+				id: "outlook",
+				name: "Outlook",
+				description: "Use inbox, calendar, and contacts from Microsoft accounts.",
+				requiresConnection: true,
+			},
+		],
+		triggers: [
+			{
+				type: "event",
+				label: "Important message arrives",
+				description: "The assistant watches for senders, keywords, and deadlines you approve.",
+			},
+			{
+				type: "message",
+				label: "Text a request",
+				description: "Ask for a summary, draft, or follow-up from chat or iOS.",
+			},
+		],
+		actions: [
+			"Build an inbox brief with action items",
+			"Draft replies and ask before sending",
+			"Create reminders for unanswered threads",
+		],
+		setupPrompt:
+			"Set up the Inbox chief of staff recipe. Help me connect Gmail or Outlook, decide what counts as important, choose when to text me, and create a safe approval flow before anything is sent.",
+	},
+	{
+		id: "meeting-to-calendar",
+		title: "Meeting action items",
+		summary: "Turn meeting notes into calendar blocks, reminders, and follow-up drafts.",
+		description:
+			"Paste notes or connect your meeting workflow so your assistant can extract decisions, owners, and due dates, then schedule the next steps while the context is fresh.",
+		kind: "automate",
+		category: "Calendar",
+		featured: true,
+		estimatedSetupMinutes: 2,
+		integrations: [
+			{
+				id: "calendar",
+				name: "Calendar",
+				description: "Create events, focus blocks, and reminders.",
+				requiresConnection: true,
+			},
+			{
+				id: "notes",
+				name: "Notes",
+				description: "Use pasted notes, uploaded docs, or connected note apps.",
+				requiresConnection: false,
+			},
+		],
+		triggers: [
+			{
+				type: "message",
+				label: "Send notes",
+				description: "Share a transcript, bullet list, or quick recap with the assistant.",
+			},
+		],
+		actions: [
+			"Extract action items with owners and due dates",
+			"Create calendar holds for next steps",
+			"Draft follow-up messages for review",
+		],
+		setupPrompt:
+			"Set up the Meeting action items recipe. Ask me what calendar to use, how to format action items, and whether you should draft follow-ups, reminders, or both after I send meeting notes.",
+	},
+	{
+		id: "health-daily-coach",
+		title: "Daily health coach",
+		summary: "Combine wearable, meal, and habit signals into a friendly daily plan.",
+		description:
+			"Bring sleep, activity, nutrition, and goals into one conversational assistant that can nudge you at the right time without making health feel like a dashboard chore.",
+		kind: "integrate",
+		category: "Health",
+		featured: true,
+		estimatedSetupMinutes: 4,
+		integrations: [
+			{
+				id: "oura",
+				name: "Oura",
+				description: "Readiness, sleep, and activity insights.",
+				requiresConnection: true,
+			},
+			{
+				id: "vision",
+				name: "Photo nutrition",
+				description: "Estimate meals from photos or labels you send.",
+				requiresConnection: false,
+			},
+		],
+		triggers: [
+			{
+				type: "schedule",
+				label: "Morning and evening check-ins",
+				description: "Choose the windows when coaching is welcome.",
+			},
+			{
+				type: "message",
+				label: "Send a meal photo",
+				description: "Ask for nutrition, macros, or a quick adjustment.",
+			},
+		],
+		actions: [
+			"Summarise readiness and sleep trends",
+			"Suggest recovery-aware workouts",
+			"Track meals from text, photos, or labels",
+		],
+		setupPrompt:
+			"Set up the Daily health coach recipe. Help me connect wearable data if available, define my goals, pick check-in times, and decide how you should respond to meal photos or nutrition labels.",
+	},
+	{
+		id: "developer-standup",
+		title: "Developer standup",
+		summary: "Summarise GitHub and Linear changes, blockers, and pull requests before standup.",
+		description:
+			"Give your assistant access to the developer systems you already use so it can produce a concise standup brief and proactively flag stale reviews or blocked issues.",
+		kind: "integrate",
+		category: "Developer",
+		featured: true,
+		estimatedSetupMinutes: 5,
+		integrations: [
+			{
+				id: "github",
+				name: "GitHub",
+				description: "Issues, pull requests, reviews, and repository activity.",
+				requiresConnection: true,
+			},
+			{
+				id: "linear",
+				name: "Linear",
+				description: "Issues, cycles, projects, and team status.",
+				requiresConnection: true,
+			},
+		],
+		triggers: [
+			{
+				type: "schedule",
+				label: "Before standup",
+				description: "Run on weekdays at the time you choose.",
+			},
+		],
+		actions: [
+			"Summarise merged PRs and open reviews",
+			"Identify blocked Linear issues",
+			"Draft a standup update in your style",
+		],
+		setupPrompt:
+			"Set up the Developer standup recipe. Help me connect GitHub and Linear, choose repositories and teams, set a weekday standup time, and define the format for my daily update.",
+	},
+	{
+		id: "travel-concierge",
+		title: "Travel concierge",
+		summary: "Track reservations, check-in windows, packing reminders, and itinerary changes.",
+		description:
+			"Forward confirmations or connect email and calendar so your assistant can maintain a living itinerary and text you when travel details change.",
+		kind: "automate",
+		category: "Travel",
+		featured: false,
+		estimatedSetupMinutes: 3,
+		integrations: [
+			{
+				id: "email",
+				name: "Email",
+				description: "Find flight, hotel, and reservation confirmations.",
+				requiresConnection: true,
+			},
+			{
+				id: "calendar",
+				name: "Calendar",
+				description: "Add itinerary holds and reminders.",
+				requiresConnection: true,
+			},
+		],
+		triggers: [
+			{
+				type: "event",
+				label: "Trip event changes",
+				description: "Monitor check-in, departure, and reservation windows.",
+			},
+		],
+		actions: [
+			"Build a live itinerary",
+			"Create packing and check-in reminders",
+			"Text changes that need attention",
+		],
+		setupPrompt:
+			"Set up the Travel concierge recipe. Ask me what trip to plan for, where to look for confirmations, when to text me, and which calendar reminders to create.",
+	},
+];
+
+export function getRecipeById(id: string) {
+	return assistantRecipes.find((recipe) => recipe.id === id);
+}
+
+export function createRecipeMessageUrl(setupPrompt: string) {
+	return `/?query=${encodeURIComponent(setupPrompt)}`;
+}

--- a/apps/app/src/components/Sidebar/StandardSidebarContent.tsx
+++ b/apps/app/src/components/Sidebar/StandardSidebarContent.tsx
@@ -1,4 +1,4 @@
-import { Home } from "lucide-react";
+import { Home, Sparkles } from "lucide-react";
 import { Link } from "react-router";
 
 import { SidebarShell } from "~/components/ui/SidebarShell";
@@ -33,6 +33,21 @@ export function StandardSidebarContent() {
 						>
 							<Home className="mr-2 h-5 w-5 flex-shrink-0" />
 							<span>Back to Home</span>
+						</Link>
+					</li>
+					<li>
+						<Link
+							to="/recipes"
+							className={cn(
+								"block w-full text-left px-3 py-2 rounded-md text-sm font-medium transition-colors duration-150 ease-in-out",
+								"text-zinc-600 hover:bg-zinc-50 hover:text-zinc-900",
+								"dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-100",
+								"no-underline",
+								"flex items-center",
+							)}
+						>
+							<Sparkles className="mr-2 h-5 w-5 flex-shrink-0" />
+							<span>Recipes</span>
 						</Link>
 					</li>
 				</ul>

--- a/apps/app/src/hooks/useRecipes.ts
+++ b/apps/app/src/hooks/useRecipes.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { installAssistantRecipe, listAssistantRecipes } from "~/lib/api/recipes";
+
+export function useAssistantRecipes() {
+	return useQuery({
+		queryKey: ["assistant-recipes"],
+		queryFn: listAssistantRecipes,
+		staleTime: 5 * 60 * 1000,
+	});
+}
+
+export function useInstallAssistantRecipe() {
+	return useMutation({
+		mutationFn: installAssistantRecipe,
+	});
+}

--- a/apps/app/src/lib/api/recipes.ts
+++ b/apps/app/src/lib/api/recipes.ts
@@ -1,0 +1,38 @@
+import type {
+	AssistantRecipe,
+	AssistantRecipeInstallResponse,
+	AssistantRecipesResponse,
+} from "@assistant/schemas";
+import { fetchApi, returnFetchedData } from "./fetch-wrapper";
+
+export async function listAssistantRecipes(): Promise<AssistantRecipesResponse> {
+	const response = await fetchApi("/apps/recipes", { method: "GET" });
+	if (!response.ok) {
+		throw new Error("Failed to fetch assistant recipes");
+	}
+
+	return returnFetchedData<AssistantRecipesResponse>(response);
+}
+
+export async function getAssistantRecipe(recipeId: string): Promise<AssistantRecipe> {
+	const response = await fetchApi(`/apps/recipes/${recipeId}`, { method: "GET" });
+	if (!response.ok) {
+		throw new Error("Failed to fetch assistant recipe");
+	}
+
+	return returnFetchedData<AssistantRecipe>(response);
+}
+
+export async function installAssistantRecipe(
+	recipeId: string,
+): Promise<AssistantRecipeInstallResponse> {
+	const response = await fetchApi(`/apps/recipes/${recipeId}/install`, {
+		method: "POST",
+		body: { channel: "web" },
+	});
+	if (!response.ok) {
+		throw new Error("Failed to start assistant recipe");
+	}
+
+	return returnFetchedData<AssistantRecipeInstallResponse>(response);
+}

--- a/apps/app/src/pages/recipes/index.tsx
+++ b/apps/app/src/pages/recipes/index.tsx
@@ -1,0 +1,265 @@
+import { useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router";
+import { Bot, CalendarClock, Check, MessageCircle, PlugZap, Search, Sparkles } from "lucide-react";
+import { toast } from "sonner";
+import type { AssistantRecipe, RecipeKind } from "@assistant/schemas";
+
+import { Button } from "~/components/ui/Button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/components/ui/Card";
+import { useAssistantRecipes, useInstallAssistantRecipe } from "~/hooks/useRecipes";
+import { cn } from "~/lib/utils";
+
+const kindLabels: Record<RecipeKind | "all", string> = {
+	all: "All",
+	automate: "Automate",
+	integrate: "Integrate",
+};
+
+function RecipeCard({
+	recipe,
+	onStart,
+	isStarting,
+}: {
+	recipe: AssistantRecipe;
+	onStart: (recipe: AssistantRecipe) => void;
+	isStarting: boolean;
+}) {
+	return (
+		<Card className="overflow-hidden border-zinc-200 bg-white/90 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg dark:border-zinc-800 dark:bg-zinc-950/80">
+			<CardHeader className="gap-4">
+				<div className="flex items-start justify-between gap-3">
+					<div className="rounded-2xl bg-blue-500/10 p-3 text-blue-600 dark:text-blue-300">
+						{recipe.kind === "automate" ? <Sparkles size={22} /> : <PlugZap size={22} />}
+					</div>
+					<div className="flex gap-2">
+						<span className="rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200">
+							{kindLabels[recipe.kind]}
+						</span>
+						{recipe.featured && (
+							<span className="rounded-full bg-amber-100 px-2.5 py-1 text-xs font-medium text-amber-800 dark:bg-amber-400/10 dark:text-amber-200">
+								Featured
+							</span>
+						)}
+					</div>
+				</div>
+				<div>
+					<CardTitle className="text-xl">{recipe.title}</CardTitle>
+					<CardDescription className="mt-2 leading-6">{recipe.summary}</CardDescription>
+				</div>
+			</CardHeader>
+			<CardContent className="flex flex-1 flex-col gap-5">
+				<p className="text-sm leading-6 text-zinc-600 dark:text-zinc-300">{recipe.description}</p>
+				<div className="flex flex-wrap gap-2">
+					{recipe.integrations.map((integration) => (
+						<span
+							key={integration.id}
+							className="rounded-full border border-zinc-200 px-2.5 py-1 text-xs text-zinc-600 dark:border-zinc-700 dark:text-zinc-300"
+						>
+							{integration.name}
+						</span>
+					))}
+				</div>
+				<div className="space-y-2 text-sm text-zinc-600 dark:text-zinc-300">
+					<div className="flex items-center gap-2">
+						<CalendarClock size={16} className="text-blue-500" />
+						<span>{recipe.estimatedSetupMinutes} min guided setup</span>
+					</div>
+					<div className="flex items-center gap-2">
+						<MessageCircle size={16} className="text-blue-500" />
+						<span>Starts as an assistant conversation</span>
+					</div>
+				</div>
+				<div className="mt-auto space-y-2">
+					{recipe.actions.slice(0, 2).map((action) => (
+						<div
+							key={action}
+							className="flex items-start gap-2 text-sm text-zinc-600 dark:text-zinc-300"
+						>
+							<Check size={15} className="mt-0.5 shrink-0 text-emerald-500" />
+							<span>{action}</span>
+						</div>
+					))}
+				</div>
+				<Button variant="primary" fullWidth onClick={() => onStart(recipe)} isLoading={isStarting}>
+					Set up in chat
+				</Button>
+			</CardContent>
+		</Card>
+	);
+}
+
+export function meta() {
+	return [
+		{ title: "Recipes - Polychat" },
+		{
+			name: "description",
+			content: "One-tap assistant recipes for automations and integrations.",
+		},
+	];
+}
+
+export default function RecipesPage() {
+	const navigate = useNavigate();
+	const [kind, setKind] = useState<RecipeKind | "all">("all");
+	const [category, setCategory] = useState("All");
+	const [search, setSearch] = useState("");
+	const { data, isLoading, error } = useAssistantRecipes();
+	const installRecipe = useInstallAssistantRecipe();
+
+	const recipes = data?.recipes ?? [];
+	const categories = ["All", ...(data?.categories ?? [])];
+	const filteredRecipes = useMemo(
+		() =>
+			recipes.filter((recipe) => {
+				const matchesKind = kind === "all" || recipe.kind === kind;
+				const matchesCategory = category === "All" || recipe.category === category;
+				const query = search.trim().toLowerCase();
+				const matchesSearch =
+					!query ||
+					[recipe.title, recipe.summary, recipe.description, recipe.category, ...recipe.actions]
+						.join(" ")
+						.toLowerCase()
+						.includes(query);
+
+				return matchesKind && matchesCategory && matchesSearch;
+			}),
+		[category, kind, recipes, search],
+	);
+
+	const handleStart = async (recipe: AssistantRecipe) => {
+		try {
+			const setup = await installRecipe.mutateAsync(recipe.id);
+			navigate(setup.messageUrl);
+		} catch (startError) {
+			console.error(startError);
+			toast.error("Could not start recipe setup. Please try again.");
+		}
+	};
+
+	return (
+		<div className="min-h-screen bg-gradient-to-b from-blue-50 via-white to-white text-zinc-950 dark:from-zinc-950 dark:via-zinc-950 dark:to-zinc-900 dark:text-zinc-50">
+			<header className="mx-auto flex max-w-7xl items-center justify-between px-6 py-6">
+				<Link to="/" className="flex items-center gap-2 font-semibold">
+					<Bot className="text-blue-600" />
+					Polychat
+				</Link>
+				<Button variant="outline" onClick={() => navigate("/")}>
+					Open chat
+				</Button>
+			</header>
+
+			<main className="mx-auto max-w-7xl px-6 pb-16 pt-8">
+				<section className="grid gap-8 lg:grid-cols-[1.2fr_0.8fr] lg:items-center">
+					<div>
+						<p className="mb-4 inline-flex rounded-full bg-blue-100 px-3 py-1 text-sm font-medium text-blue-700 dark:bg-blue-500/10 dark:text-blue-200">
+							Assistant Recipes
+						</p>
+						<h1 className="max-w-3xl text-4xl font-semibold tracking-tight sm:text-6xl">
+							Set up automations with one assistant conversation.
+						</h1>
+						<p className="mt-5 max-w-2xl text-lg leading-8 text-zinc-600 dark:text-zinc-300">
+							Pick a recipe, then Polychat opens a guided chat to connect tools, choose triggers,
+							confirm privacy boundaries, and test the setup before anything runs automatically.
+						</p>
+					</div>
+					<div className="rounded-3xl border border-blue-100 bg-white p-6 shadow-xl dark:border-zinc-800 dark:bg-zinc-950">
+						<div className="space-y-4">
+							{[
+								"Choose a recipe",
+								"Connect integrations",
+								"Message your assistant",
+								"Approve automations",
+							].map((step, index) => (
+								<div
+									key={step}
+									className="flex items-center gap-3 rounded-2xl bg-zinc-50 p-4 dark:bg-zinc-900"
+								>
+									<span className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
+										{index + 1}
+									</span>
+									<span className="font-medium">{step}</span>
+								</div>
+							))}
+						</div>
+					</div>
+				</section>
+
+				<section className="mt-12 space-y-5">
+					<div className="flex flex-col gap-4 rounded-3xl border border-zinc-200 bg-white/80 p-4 shadow-sm backdrop-blur dark:border-zinc-800 dark:bg-zinc-950/80 lg:flex-row lg:items-center">
+						<div className="relative flex-1">
+							<Search
+								className="absolute left-3 top-1/2 -translate-y-1/2 text-zinc-400"
+								size={18}
+							/>
+							<input
+								value={search}
+								onChange={(event) => setSearch(event.target.value)}
+								placeholder="Search email, health, developer, travel..."
+								className="w-full rounded-2xl border border-zinc-200 bg-white py-3 pl-10 pr-4 outline-none transition focus:border-blue-400 dark:border-zinc-800 dark:bg-zinc-900"
+							/>
+						</div>
+						<div className="flex flex-wrap gap-2">
+							{(["all", "automate", "integrate"] as const).map((nextKind) => (
+								<button
+									key={nextKind}
+									onClick={() => setKind(nextKind)}
+									className={cn(
+										"rounded-full px-4 py-2 text-sm font-medium transition",
+										kind === nextKind
+											? "bg-blue-600 text-white"
+											: "bg-zinc-100 text-zinc-700 hover:bg-zinc-200 dark:bg-zinc-900 dark:text-zinc-200 dark:hover:bg-zinc-800",
+									)}
+								>
+									{kindLabels[nextKind]}
+								</button>
+							))}
+						</div>
+					</div>
+
+					<div className="flex flex-wrap gap-2">
+						{categories.map((nextCategory) => (
+							<button
+								key={nextCategory}
+								onClick={() => setCategory(nextCategory)}
+								className={cn(
+									"rounded-full border px-3 py-1.5 text-sm transition",
+									category === nextCategory
+										? "border-blue-600 bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-200"
+										: "border-zinc-200 text-zinc-600 hover:border-zinc-300 dark:border-zinc-800 dark:text-zinc-300",
+								)}
+							>
+								{nextCategory}
+							</button>
+						))}
+					</div>
+				</section>
+
+				{error ? (
+					<div className="mt-12 rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-200">
+						Failed to load recipes. Please refresh and try again.
+					</div>
+				) : isLoading ? (
+					<div className="mt-12 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+						{Array.from({ length: 6 }).map((_, index) => (
+							<div
+								key={index}
+								className="h-80 animate-pulse rounded-2xl bg-zinc-100 dark:bg-zinc-900"
+							/>
+						))}
+					</div>
+				) : (
+					<div className="mt-12 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
+						{filteredRecipes.map((recipe) => (
+							<RecipeCard
+								key={recipe.id}
+								recipe={recipe}
+								onStart={handleStart}
+								isStarting={installRecipe.isPending && installRecipe.variables === recipe.id}
+							/>
+						))}
+					</div>
+				)}
+			</main>
+		</div>
+	);
+}

--- a/apps/app/src/routes.ts
+++ b/apps/app/src/routes.ts
@@ -10,6 +10,7 @@ export default [
 	route("/s/:share_id", "pages/shared/[share_id].tsx"),
 	route("/s/apps/:share_id", "pages/shared/apps/[share_id].tsx"),
 	route("/apps", "pages/apps/index.tsx"),
+	route("/recipes", "pages/recipes/index.tsx"),
 	route("/apps/responses", "pages/apps/responses/index.tsx"),
 	route("/apps/responses/:responseId", "pages/apps/responses/[responseId].tsx"),
 	route("/apps/podcasts", "pages/apps/podcasts/index.tsx"),

--- a/apps/mobile/ios/Polychat/ContentView.swift
+++ b/apps/mobile/ios/Polychat/ContentView.swift
@@ -8,6 +8,7 @@ struct ContentView: View {
     @State private var columnVisibility = NavigationSplitViewVisibility.doubleColumn
     @State private var selectedConversationID: String?
     @State private var showingSettings = false
+    @State private var showingRecipes = false
     @State private var conversationLoadTask: Task<Void, Never>?
 
     private var isLoadingSelectedConversation: Bool {
@@ -25,9 +26,15 @@ struct ContentView: View {
                 LaunchLoadingView()
             } else if authManager.isAuthenticated {
                 NavigationSplitView(columnVisibility: $columnVisibility) {
-                    ConversationListView(selectedConversationID: $selectedConversationID) {
-                        showingSettings = true
-                    }
+                    ConversationListView(
+                        selectedConversationID: $selectedConversationID,
+                        onShowSettings: {
+                            showingSettings = true
+                        },
+                        onShowRecipes: {
+                            showingRecipes = true
+                        }
+                    )
                 } detail: {
                     if conversationManager.currentConversation != nil {
                         ChatView()
@@ -39,6 +46,12 @@ struct ContentView: View {
                 }
                 .sheet(isPresented: $showingSettings) {
                     SettingsView()
+                }
+                .sheet(isPresented: $showingRecipes) {
+                    RecipesView { starter in
+                        showingRecipes = false
+                        startRecipeConversation(starter)
+                    }
                 }
                 .task(id: authManager.isAuthenticated) {
                     if authManager.isAuthenticated {
@@ -71,6 +84,19 @@ struct ContentView: View {
         }
         .onOpenURL { url in
             authManager.handleOpenURL(url)
+        }
+    }
+
+    private func startRecipeConversation(_ starter: String) {
+        let conversation = conversationManager.startNewConversation()
+        selectedConversationID = conversation.id
+
+        Task {
+            do {
+                try await conversationManager.addMessage(ChatMessage(role: "user", content: starter))
+            } catch {
+                conversationManager.error = "Failed to start recipe: \(error.localizedDescription)"
+            }
         }
     }
 }
@@ -134,4 +160,200 @@ private struct EmptyConversationView: View {
         .environmentObject(ConversationManager())
         .environmentObject(ModelsStore())
         .environmentObject(ToolsStore())
+}
+
+
+private struct RecipesView: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var response: AssistantRecipesResponse?
+    @State private var selectedKind = "all"
+    @State private var selectedCategory = "All"
+    @State private var searchText = ""
+    @State private var isLoading = false
+    @State private var installingRecipeID: String?
+    @State private var errorMessage: String?
+
+    let onStart: (String) -> Void
+
+    private var recipes: [AssistantRecipe] {
+        let allRecipes = response?.recipes ?? []
+        return allRecipes.filter { recipe in
+            let matchesKind = selectedKind == "all" || recipe.kind == selectedKind
+            let matchesCategory = selectedCategory == "All" || recipe.category == selectedCategory
+            let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let matchesSearch = query.isEmpty || [recipe.title, recipe.summary, recipe.description, recipe.category].joined(separator: " ").localizedCaseInsensitiveContains(query)
+            return matchesKind && matchesCategory && matchesSearch
+        }
+    }
+
+    private var categories: [String] {
+        ["All"] + (response?.categories ?? [])
+    }
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if isLoading && response == nil {
+                    ProgressView("Loading recipes...")
+                } else if let errorMessage {
+                    ContentUnavailableView("Recipes unavailable", systemImage: "exclamationmark.triangle", description: Text(errorMessage))
+                } else {
+                    List {
+                        Section {
+                            VStack(alignment: .leading, spacing: 10) {
+                                Text("Assistant Recipes")
+                                    .font(.largeTitle.bold())
+                                Text("Set up integrations, automations, and proactive check-ins through a guided assistant chat.")
+                                    .foregroundStyle(.secondary)
+                            }
+                            .padding(.vertical, 8)
+                        }
+                        .listRowBackground(Color.clear)
+
+                        Section {
+                            Picker("Type", selection: $selectedKind) {
+                                Text("All").tag("all")
+                                Text("Automate").tag("automate")
+                                Text("Integrate").tag("integrate")
+                            }
+                            .pickerStyle(.segmented)
+
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack {
+                                    ForEach(categories, id: \.self) { category in
+                                        Button {
+                                            selectedCategory = category
+                                        } label: {
+                                            Text(category)
+                                                .font(.caption.weight(.semibold))
+                                                .padding(.horizontal, 12)
+                                                .padding(.vertical, 7)
+                                                .background(selectedCategory == category ? Color.polychat.primary.opacity(0.16) : Color.secondary.opacity(0.10))
+                                                .clipShape(Capsule())
+                                        }
+                                        .buttonStyle(.plain)
+                                    }
+                                }
+                                .padding(.vertical, 4)
+                            }
+                        }
+
+                        Section {
+                            ForEach(recipes) { recipe in
+                                RecipeRow(
+                                    recipe: recipe,
+                                    isInstalling: installingRecipeID == recipe.id,
+                                    onInstall: {
+                                        install(recipe)
+                                    }
+                                )
+                            }
+                        }
+                    }
+                    .searchable(text: $searchText, prompt: "Search recipes")
+                    .refreshable {
+                        await loadRecipes()
+                    }
+                }
+            }
+            .navigationTitle("Recipes")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .task {
+                await loadRecipes()
+            }
+        }
+    }
+
+    private func loadRecipes() async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            response = try await APIClient.shared.fetchAssistantRecipes()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    private func install(_ recipe: AssistantRecipe) {
+        installingRecipeID = recipe.id
+        Task {
+            do {
+                let setup = try await APIClient.shared.installAssistantRecipe(id: recipe.id)
+                installingRecipeID = nil
+                onStart(setup.conversationStarter)
+            } catch {
+                installingRecipeID = nil
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+}
+
+private struct RecipeRow: View {
+    let recipe: AssistantRecipe
+    let isInstalling: Bool
+    let onInstall: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(recipe.title)
+                        .font(.headline)
+                    Text(recipe.summary)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                if recipe.featured {
+                    Text("Featured")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.orange)
+                }
+            }
+
+            Text(recipe.description)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack {
+                Label("\(recipe.estimatedSetupMinutes) min", systemImage: "clock")
+                Label(recipe.category, systemImage: recipe.kind == "automate" ? "wand.and.stars" : "puzzlepiece.extension")
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack {
+                    ForEach(recipe.integrations) { integration in
+                        Text(integration.name)
+                            .font(.caption.weight(.medium))
+                            .padding(.horizontal, 9)
+                            .padding(.vertical, 5)
+                            .background(Color.secondary.opacity(0.10))
+                            .clipShape(Capsule())
+                    }
+                }
+            }
+
+            Button(action: onInstall) {
+                if isInstalling {
+                    ProgressView()
+                        .frame(maxWidth: .infinity)
+                } else {
+                    Label("Set up in chat", systemImage: "message.badge")
+                        .frame(maxWidth: .infinity)
+                }
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(isInstalling)
+        }
+        .padding(.vertical, 8)
+    }
 }

--- a/apps/mobile/ios/Polychat/Models/APIModels.swift
+++ b/apps/mobile/ios/Polychat/Models/APIModels.swift
@@ -279,6 +279,53 @@ public struct ToolDefinition: Codable, Identifiable, Equatable {
     public let isDefault: Bool?
 }
 
+
+
+public struct AssistantRecipesResponse: Codable {
+    public let recipes: [AssistantRecipe]
+    public let categories: [String]
+    public let filters: [String]
+}
+
+public struct AssistantRecipe: Codable, Identifiable, Equatable {
+    public let id: String
+    public let title: String
+    public let summary: String
+    public let description: String
+    public let kind: String
+    public let category: String
+    public let featured: Bool
+    public let estimatedSetupMinutes: Int
+    public let integrations: [AssistantRecipeIntegration]
+    public let triggers: [AssistantRecipeTrigger]
+    public let actions: [String]
+    public let setupPrompt: String
+}
+
+public struct AssistantRecipeIntegration: Codable, Identifiable, Equatable {
+    public let id: String
+    public let name: String
+    public let description: String
+    public let requiresConnection: Bool
+}
+
+public struct AssistantRecipeTrigger: Codable, Equatable {
+    public let type: String
+    public let label: String
+    public let description: String
+}
+
+public struct AssistantRecipeInstallRequest: Codable {
+    let channel: String
+}
+
+public struct AssistantRecipeInstallResponse: Codable {
+    public let recipe: AssistantRecipe
+    public let conversationStarter: String
+    public let messageUrl: String
+    public let checklist: [String]
+}
+
 public struct TitleGenerationRequest: Codable {
     let messages: [ChatMessage]
 }

--- a/apps/mobile/ios/Polychat/Services/APIClient.swift
+++ b/apps/mobile/ios/Polychat/Services/APIClient.swift
@@ -129,6 +129,19 @@ final class APIClient: ObservableObject {
         try await send(path: "/tools", method: "GET")
     }
 
+
+    func fetchAssistantRecipes() async throws -> AssistantRecipesResponse {
+        try await send(path: "/apps/recipes", method: "GET")
+    }
+
+    func installAssistantRecipe(id: String) async throws -> AssistantRecipeInstallResponse {
+        try await send(
+            path: "/apps/recipes/\(id)/install",
+            method: "POST",
+            body: AssistantRecipeInstallRequest(channel: "ios")
+        )
+    }
+
     func generateTitle(conversationId: String, messages: [ChatMessage]) async throws -> TitleGenerationResponse {
         try await send(
             path: "/chat/completions/\(conversationId)/generate-title",

--- a/apps/mobile/ios/Polychat/Services/APIClientProtocols.swift
+++ b/apps/mobile/ios/Polychat/Services/APIClientProtocols.swift
@@ -8,6 +8,11 @@ protocol ToolsAPIClient {
     func fetchTools() async throws -> [ToolDefinition]
 }
 
+protocol RecipesAPIClient {
+    func fetchAssistantRecipes() async throws -> AssistantRecipesResponse
+    func installAssistantRecipe(id: String) async throws -> AssistantRecipeInstallResponse
+}
+
 protocol ConversationAPIClient {
     func fetchConversations(limit: Int, page: Int, includeArchived: Bool) async throws -> ConversationListResponse
     func fetchConversation(id: String, refreshPending: Bool) async throws -> ConversationDetailResponse
@@ -33,4 +38,4 @@ extension ConversationAPIClient {
     }
 }
 
-extension APIClient: ModelsAPIClient, ToolsAPIClient, ConversationAPIClient {}
+extension APIClient: ModelsAPIClient, ToolsAPIClient, RecipesAPIClient, ConversationAPIClient {}

--- a/apps/mobile/ios/Polychat/Views/ConversationListView.swift
+++ b/apps/mobile/ios/Polychat/Views/ConversationListView.swift
@@ -6,13 +6,16 @@ struct ConversationListView: View {
     @Binding var selectedConversationID: String?
     @State private var searchText = ""
     let onShowSettings: () -> Void
+    let onShowRecipes: () -> Void
 
     init(
         selectedConversationID: Binding<String?>,
-        onShowSettings: @escaping () -> Void = {}
+        onShowSettings: @escaping () -> Void = {},
+        onShowRecipes: @escaping () -> Void = {}
     ) {
         self._selectedConversationID = selectedConversationID
         self.onShowSettings = onShowSettings
+        self.onShowRecipes = onShowRecipes
     }
 
     private var filteredConversations: [Conversation] {
@@ -95,6 +98,14 @@ struct ConversationListView: View {
                     Image(systemName: "square.and.pencil")
                 }
                 .accessibilityLabel("New Message")
+            }
+
+            ToolbarItem(placement: .secondaryAction) {
+                Button {
+                    onShowRecipes()
+                } label: {
+                    Label("Recipes", systemImage: "sparkles")
+                }
             }
 
             ToolbarItem(placement: .secondaryAction) {

--- a/packages/schemas/src/apps.ts
+++ b/packages/schemas/src/apps.ts
@@ -946,3 +946,73 @@ export const strudelListPatternsResponseSchema = z.object({
 export const strudelPatternDetailResponseSchema = z.object({
 	pattern: strudelPatternSchema,
 });
+
+export const recipeCategorySchema = z.enum([
+	"Calendar",
+	"Community",
+	"Developer",
+	"Email",
+	"Finance",
+	"Health",
+	"Home",
+	"Productivity",
+	"Scheduling",
+	"Shopping",
+	"Students",
+	"To-dos",
+	"Travel",
+]);
+
+export const recipeKindSchema = z.enum(["automate", "integrate"]);
+
+export const recipeTriggerSchema = z.object({
+	type: z.enum(["message", "schedule", "event"]),
+	label: z.string(),
+	description: z.string(),
+});
+
+export const recipeIntegrationSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+	description: z.string(),
+	requiresConnection: z.boolean().default(true),
+});
+
+export const assistantRecipeSchema = z.object({
+	id: z.string(),
+	title: z.string(),
+	summary: z.string(),
+	description: z.string(),
+	kind: recipeKindSchema,
+	category: recipeCategorySchema,
+	featured: z.boolean(),
+	estimatedSetupMinutes: z.number().int().positive(),
+	integrations: z.array(recipeIntegrationSchema),
+	triggers: z.array(recipeTriggerSchema),
+	actions: z.array(z.string()),
+	setupPrompt: z.string(),
+});
+
+export const assistantRecipesResponseSchema = z.object({
+	recipes: z.array(assistantRecipeSchema),
+	categories: z.array(recipeCategorySchema),
+	filters: z.array(recipeKindSchema),
+});
+
+export const assistantRecipeInstallRequestSchema = z.object({
+	channel: z.enum(["web", "ios", "sms"]).default("web"),
+});
+
+export const assistantRecipeInstallResponseSchema = z.object({
+	recipe: assistantRecipeSchema,
+	conversationStarter: z.string(),
+	messageUrl: z.string(),
+	checklist: z.array(z.string()),
+});
+
+export type RecipeCategory = z.infer<typeof recipeCategorySchema>;
+export type RecipeKind = z.infer<typeof recipeKindSchema>;
+export type AssistantRecipe = z.infer<typeof assistantRecipeSchema>;
+export type AssistantRecipesResponse = z.infer<typeof assistantRecipesResponseSchema>;
+export type AssistantRecipeInstallRequest = z.infer<typeof assistantRecipeInstallRequestSchema>;
+export type AssistantRecipeInstallResponse = z.infer<typeof assistantRecipeInstallResponseSchema>;


### PR DESCRIPTION
### Motivation
- Add a recipes/assistant-setup system (like poke.com/recipes) so users can pick one-tap assistant setups that launch a guided conversational configuration and handoff into chat or SMS/iOS.
- Provide shared types/schema for recipes so API, web, and iOS clients can agree on payloads for listing, installing, and starting guided setups.
- Surface recipes in the web app and mobile app UI so users can browse, filter, and start setups with a single click.

### Description
- Added shared schema/types for recipes in `packages/schemas/src/apps.ts` (`assistantRecipeSchema`, `assistantRecipesResponseSchema`, install request/response, categories, triggers, integrations, etc.).
- Implemented a static recipe catalog and API routes: `apps/api/src/services/apps/recipes.ts` (catalog + helpers) and `apps/api/src/routes/apps/recipes.ts` (endpoints: `GET /apps/recipes`, `GET /apps/recipes/:id`, `POST /apps/recipes/:id/install`), and registered the recipes route in `apps/api/src/routes/apps/index.ts`.
- Web client: added API wrapper `apps/app/src/lib/api/recipes.ts`, React hooks `apps/app/src/hooks/useRecipes.ts`, a new page `apps/app/src/pages/recipes/index.tsx` with search/filter/cards and a `Set up in chat` handoff, added route entry in `apps/app/src/routes.ts`, and added a sidebar link in `apps/app/src/components/Sidebar/StandardSidebarContent.tsx`.
- iOS client: extended models `apps/mobile/ios/Polychat/Models/APIModels.swift` with recipe types and install response, added client methods `fetchAssistantRecipes` and `installAssistantRecipe` to `APIClient.swift`, updated `APIClientProtocols.swift`, and added an in-app `RecipesView` and wiring in `ContentView.swift` / `ConversationListView.swift` to show recipes and start a new conversation populated with the generated starter prompt.
- Minor formatting and integration changes to register routes and keep types consistent across platforms.

### Testing
- Ran typecheck and lint for API and app: `pnpm --filter @assistant/api typecheck` and `pnpm --filter @assistant/app typecheck` and lints; these completed successfully (typechecks passed, lint showed only unrelated warnings).
- Built the web app: `pnpm --filter @assistant/app build` completed successfully (production build created).
- Ran formatting commands: `pnpm --filter @assistant/api format && pnpm --filter @assistant/app format && pnpm --filter @assistant/schemas format` completed.
- Mobile tests: `pnpm test:mobile` failed/blocked in this environment due to missing Xcode tools (`xcrun`/`xcodebuild` not available), so iOS runtime tests could not be executed here.
- Playwright screenshot attempt: `pnpm exec playwright install chromium && pnpm exec playwright screenshot http://localhost:5173/recipes /tmp/.../recipes.png` was attempted but failed because the Playwright browser download returned 403 in this environment, so automated UI screenshot verification did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24950431c4832ab92077abd0d4c113)