### PR TITLE
Add iOS user message editing and regeneration

### DIFF
--- a/apps/mobile/ios/Polychat/Models/ChatMessage.swift
+++ b/apps/mobile/ios/Polychat/Models/ChatMessage.swift
@@ -288,20 +288,91 @@ public struct ChatMessage: Codable, Identifiable, Equatable {
         artifacts: [Artifact]? = nil,
         model: String? = nil
     ) {
+        self.init(
+            id: id,
+            role: role,
+            content: .multimodal(contentBlocks),
+            artifacts: artifacts,
+            model: model
+        )
+    }
+
+    public init(
+        id: String = UUID().uuidString,
+        role: String,
+        content: MessageContent,
+        artifacts: [Artifact]? = nil,
+        model: String? = nil,
+        parts: [ChatMessagePart]? = nil,
+        reasoning: ChatReasoning? = nil,
+        citations: [ChatCitation]? = nil,
+        data: ChatMessageData? = nil,
+        name: String? = nil,
+        status: String? = nil,
+        logId: String? = nil,
+        created: Double? = nil,
+        timestamp: Double? = nil
+    ) {
         self.id = id
         self.role = role
-        self.content = .multimodal(contentBlocks)
+        self.content = content
         self.artifacts = artifacts
         self.model = model
-        self.parts = nil
-        self.reasoning = nil
-        self.citations = nil
-        self.data = nil
-        self.name = nil
-        self.status = nil
-        self.logId = nil
-        self.created = nil
-        self.timestamp = nil
+        self.parts = parts
+        self.reasoning = reasoning
+        self.citations = citations
+        self.data = data
+        self.name = name
+        self.status = status
+        self.logId = logId
+        self.created = created
+        self.timestamp = timestamp
+    }
+
+    public func replacingTextContent(with text: String) -> ChatMessage {
+        let updatedContent: MessageContent
+
+        switch content {
+        case .text:
+            updatedContent = .text(text)
+        case .multimodal(let blocks):
+            var didReplaceText = false
+            var updatedBlocks = blocks.compactMap { block -> MessageContentBlock? in
+                switch block {
+                case .text:
+                    if didReplaceText {
+                        return nil
+                    }
+                    didReplaceText = true
+                    return .text(MessageContentBlock.TextBlock(text: text))
+                default:
+                    return block
+                }
+            }
+
+            if !didReplaceText {
+                updatedBlocks.insert(.text(MessageContentBlock.TextBlock(text: text)), at: 0)
+            }
+
+            updatedContent = .multimodal(updatedBlocks)
+        }
+
+        return ChatMessage(
+            id: id,
+            role: role,
+            content: updatedContent,
+            artifacts: artifacts,
+            model: model,
+            parts: parts,
+            reasoning: reasoning,
+            citations: citations,
+            data: data,
+            name: name,
+            status: status,
+            logId: logId,
+            created: created,
+            timestamp: timestamp
+        )
     }
 
     enum CodingKeys: String, CodingKey {

--- a/apps/mobile/ios/Polychat/Services/ConversationManager.swift
+++ b/apps/mobile/ios/Polychat/Services/ConversationManager.swift
@@ -175,7 +175,7 @@ class ConversationManager: ObservableObject {
     }
 
     func regenerateAssistantMessage(_ messageId: String, settings: ChatSettings? = nil) async {
-        guard var conversation = currentConversation,
+        guard let conversation = currentConversation,
               let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId }) else {
             error = "Unable to retry: message not found"
             return
@@ -193,9 +193,52 @@ class ConversationManager: ObservableObject {
             return
         }
 
+        await regenerateConversation(
+            conversation,
+            through: retryEndIndex,
+            settings: settings,
+            missingUserError: "Unable to retry without a user message"
+        )
+    }
+
+    func editUserMessage(_ messageId: String, text: String, settings: ChatSettings? = nil) async {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedText.isEmpty else {
+            error = "Message cannot be empty"
+            return
+        }
+
+        guard let conversation = currentConversation,
+              let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId }) else {
+            error = "Unable to edit: message not found"
+            return
+        }
+
+        guard conversation.messages[messageIndex].role == "user" else {
+            error = "Only user messages can be edited"
+            return
+        }
+
+        conversation.messages[messageIndex] = conversation.messages[messageIndex].replacingTextContent(with: trimmedText)
+
+        await regenerateConversation(
+            conversation,
+            through: messageIndex + 1,
+            settings: settings,
+            missingUserError: "Unable to regenerate without a user message"
+        )
+    }
+
+    private func regenerateConversation(
+        _ conversation: Conversation,
+        through retryEndIndex: Int,
+        settings: ChatSettings?,
+        missingUserError: String
+    ) async {
+        var conversation = conversation
         let requestMessages = Array(conversation.messages.prefix(retryEndIndex))
         guard requestMessages.contains(where: { $0.role == "user" }) else {
-            error = "Unable to retry without a user message"
+            error = missingUserError
             return
         }
 

--- a/apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift
+++ b/apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift
@@ -4,6 +4,8 @@ struct MessageBubble: View {
     let conversationModelId: String?
     @EnvironmentObject var conversationManager: ConversationManager
     @EnvironmentObject var modelsStore: ModelsStore
+    @State private var isEditingUserMessage = false
+    @State private var editedMessageText = ""
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -64,6 +66,15 @@ struct MessageBubble: View {
                             .accessibilityLabel("Retry message")
                         }
 
+                        if message.role == "user" {
+                            Button(action: beginEditingUserMessage) {
+                                Image(systemName: "pencil")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .accessibilityLabel("Edit message")
+                        }
+
                         Button(action: copyMessage) {
                             Image(systemName: "doc.on.doc")
                                 .font(.caption)
@@ -79,6 +90,16 @@ struct MessageBubble: View {
             }
         }
         .frame(maxWidth: .infinity)
+        .alert("Edit Message", isPresented: $isEditingUserMessage) {
+            TextField("Message", text: $editedMessageText)
+            Button("Cancel", role: .cancel) {}
+            Button("Save") {
+                saveEditedUserMessage()
+            }
+            .disabled(editedMessageText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        } message: {
+            Text("Saving will rerun the conversation from this message and remove later replies.")
+        }
     }
 
     private var messageBackground: Color {
@@ -143,6 +164,18 @@ struct MessageBubble: View {
     private func regenerateMessage() {
         Task {
             await conversationManager.regenerateAssistantMessage(message.id)
+        }
+    }
+
+    private func beginEditingUserMessage() {
+        editedMessageText = message.textContent
+        isEditingUserMessage = true
+    }
+
+    private func saveEditedUserMessage() {
+        let newText = editedMessageText
+        Task {
+            await conversationManager.editUserMessage(message.id, text: newText)
         }
     }
 

--- a/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
+++ b/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
@@ -147,6 +147,76 @@ struct ServiceStoreTests {
     }
 
     @MainActor
+    @Test func conversationManagerEditsUserMessageAndRegeneratesFromThatPoint() async throws {
+        let apiClient = ConversationAPIClientStub()
+        apiClient.streamEvents = [
+            .content("Edited answer"),
+            .done
+        ]
+
+        let manager = ConversationManager()
+        manager.configure(apiClient: apiClient)
+        let conversation = manager.startNewConversation()
+        manager.currentConversation?.messages = [
+            ChatMessage(id: "user-1", role: "user", content: "Original question"),
+            ChatMessage(id: "assistant-1", role: "assistant", content: "Old answer"),
+            ChatMessage(id: "user-2", role: "user", content: "Follow up")
+        ]
+        if let currentConversation = manager.currentConversation {
+            manager.conversations = [currentConversation]
+        }
+
+        await manager.editUserMessage("user-1", text: "  Edited question  ")
+
+        #expect(apiClient.streamCallCount == 1)
+        #expect(apiClient.streamedCompletionId == conversation.id)
+        #expect(apiClient.streamedMessages.map(\.id) == ["user-1"])
+        #expect(apiClient.streamedMessages.first?.textContent == "Edited question")
+        #expect(manager.currentConversation?.messages.map(\.role) == ["user", "assistant"])
+        #expect(manager.currentConversation?.messages.first?.textContent == "Edited question")
+        #expect(manager.currentConversation?.messages.last?.textContent == "Edited answer")
+    }
+
+    @MainActor
+    @Test func conversationManagerEditingMultimodalUserMessagePreservesAttachments() async throws {
+        let apiClient = ConversationAPIClientStub()
+        apiClient.streamEvents = [
+            .content("Looked at the image"),
+            .done
+        ]
+
+        let manager = ConversationManager()
+        manager.configure(apiClient: apiClient)
+        let conversation = manager.startNewConversation()
+        let imageBlock = MessageContentBlock.imageUrl(.init(url: "https://example.com/image.png"))
+        manager.currentConversation?.messages = [
+            ChatMessage(
+                id: "user-1",
+                role: "user",
+                contentBlocks: [
+                    .text(.init(text: "Original caption")),
+                    imageBlock
+                ]
+            ),
+            ChatMessage(id: "assistant-1", role: "assistant", content: "Old image answer")
+        ]
+        if let currentConversation = manager.currentConversation {
+            manager.conversations = [currentConversation]
+        }
+
+        await manager.editUserMessage("user-1", text: "Updated caption")
+
+        #expect(apiClient.streamedCompletionId == conversation.id)
+        #expect(apiClient.streamedMessages.first?.textContent == "Updated caption")
+        guard case .multimodal(let streamedBlocks)? = apiClient.streamedMessages.first?.content else {
+            Issue.record("Expected multimodal content to be preserved")
+            return
+        }
+        #expect(streamedBlocks.contains(imageBlock))
+        #expect(manager.currentConversation?.messages.first?.textContent == "Updated caption")
+    }
+
+    @MainActor
     @Test func conversationManagerPersistsRenamedLoadedConversation() async throws {
         let apiClient = ConversationAPIClientStub()
         let manager = ConversationManager()


### PR DESCRIPTION
### Motivation
- Provide parity with the web app by allowing users to edit their messages in the iOS chat UI and re-run the assistant from that point to avoid stale replies.
- Preserve multimodal attachments when editing only the text portion of a message so images/documents remain intact.

### Description
- Add an edit affordance and UI in `apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift` that shows an edit alert and calls the manager to save edits via `beginEditingUserMessage`/`saveEditedUserMessage`.
- Implement `editUserMessage` and a shared `regenerateConversation` helper in `apps/mobile/ios/Polychat/Services/ConversationManager.swift` to validate edits, trim empty input, replace message text, truncate later replies, and stream a new assistant response.
- Add `ChatMessage` convenience initializers and `replacingTextContent(with:)` in `apps/mobile/ios/Polychat/Models/ChatMessage.swift` to perform safe text replacement while preserving multimodal blocks and artifacts.
- Add unit tests in `apps/mobile/ios/PolychatTests/ServiceStoreTests.swift` covering editing a plain user message and editing a multimodal message (ensuring attachments are preserved and the stream request uses updated content).

### Testing
- Ran `git diff --check` which passed without whitespace/errors.
- Attempted `pnpm test:mobile` (which invokes the iOS test script), but the environment lacks `xcrun`/`xcodebuild` and an iOS simulator runtime so the test run could not be executed here; unit tests were added and should run in a macOS/Xcode CI or developer machine with iOS tooling available.
- Added unit tests: `conversationManagerEditsUserMessageAndRegeneratesFromThatPoint` and `conversationManagerEditingMultimodalUserMessagePreservesAttachments` (located in `apps/mobile/ios/PolychatTests/ServiceStoreTests.swift`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a249ac63040832a805b8ec70418f25e)