### PR TITLE
Add conversation branching on iOS and persist branch metadata

### DIFF
--- a/apps/app/src/lib/__test__/messages.test.ts
+++ b/apps/app/src/lib/__test__/messages.test.ts
@@ -1,8 +1,11 @@
-import { createChatCompletionsJsonSchema } from "@assistant/schemas";
+import { createChatCompletionsJsonSchema, messageSchema } from "@assistant/schemas";
 import { describe, expect, it } from "vitest";
 
 import type { Message } from "~/types";
-import { serialiseMessagesForChatRequest } from "../messages";
+import {
+	serialiseMessagesForChatRequest,
+	serialiseMessagesForConversationUpdate,
+} from "../messages";
 
 describe("serialiseMessagesForChatRequest", () => {
 	it("removes reasoning-only content blocks from replayed assistant messages", () => {
@@ -81,5 +84,35 @@ describe("serialiseMessagesForChatRequest", () => {
 				messages: requestMessages,
 			}).success,
 		).toBe(true);
+	});
+});
+
+describe("serialiseMessagesForConversationUpdate", () => {
+	it("encodes citation objects as URL strings for persisted branch updates", () => {
+		const messages = JSON.parse(`[
+			{
+				"id": "assistant-1",
+				"role": "assistant",
+				"content": "Answer with citations",
+				"citations": [
+					{
+						"url": "https://example.com/source",
+						"title": "Example source"
+					},
+					"https://example.com/already-string",
+					{
+						"title": "Missing URL"
+					}
+				]
+			}
+		]`);
+
+		const requestMessages = serialiseMessagesForConversationUpdate(messages);
+
+		expect(requestMessages[0]?.citations).toEqual([
+			"https://example.com/source",
+			"https://example.com/already-string",
+		]);
+		expect(messageSchema.safeParse(requestMessages[0]).success).toBe(true);
 	});
 });

--- a/apps/app/src/lib/api/services/chat-service.test.ts
+++ b/apps/app/src/lib/api/services/chat-service.test.ts
@@ -280,16 +280,29 @@ describe("ChatService conversation updates", () => {
 		vi.stubGlobal("fetch", fetchMock);
 
 		const service = new ChatService(async () => ({}));
+		const messages = JSON.parse(`[
+			{
+				"id": "message-1",
+				"role": "user",
+				"content": "Hello",
+				"citations": null,
+				"timestamp": 1000
+			},
+			{
+				"id": "message-2",
+				"role": "assistant",
+				"content": "Answer",
+				"citations": [
+					{
+						"url": "https://example.com/source",
+						"title": "Example source"
+					}
+				],
+				"timestamp": 1001
+			}
+		]`);
 		const result = await service.updateConversation("conversation-1", {
-			messages: [
-				{
-					id: "message-1",
-					role: "user",
-					content: "Hello",
-					citations: null,
-					timestamp: 1000,
-				} as Message,
-			],
+			messages,
 		});
 
 		const [url, request] = fetchMock.mock.calls[0];
@@ -297,14 +310,15 @@ describe("ChatService conversation updates", () => {
 
 		expect(String(url)).toContain("/chat/completions/conversation-1");
 		expect(request?.method).toBe("PUT");
-		expect(body.messages).toEqual([
+		expect(body.messages[0]).toEqual(
 			expect.objectContaining({
 				content: "Hello",
 				id: "message-1",
 				role: "user",
 			}),
-		]);
+		);
 		expect(body.messages[0]).not.toHaveProperty("citations");
+		expect(body.messages[1].citations).toEqual(["https://example.com/source"]);
 		expect(result.messages).toEqual([
 			expect.objectContaining({
 				content: "Hello",

--- a/apps/app/src/lib/messages.ts
+++ b/apps/app/src/lib/messages.ts
@@ -1,4 +1,5 @@
 import type { Message, MessageContent } from "~/types";
+import { isRecord } from "./objects";
 
 type ChatRequestMessage = {
 	id?: string;
@@ -48,6 +49,31 @@ const chatRequestContentTypes = new Set([
 	"document_url",
 	"markdown_document",
 ]);
+
+function serialiseCitationForConversationUpdate(citation: unknown): string | null {
+	if (typeof citation === "string") {
+		return citation;
+	}
+
+	if (!isRecord(citation)) {
+		return null;
+	}
+
+	return typeof citation.url === "string" ? citation.url : null;
+}
+
+function serialiseCitationsForConversationUpdate(citations: unknown): string[] | undefined {
+	if (!Array.isArray(citations)) {
+		return undefined;
+	}
+
+	const serialised = citations.flatMap((citation) => {
+		const value = serialiseCitationForConversationUpdate(citation);
+		return value ? [value] : [];
+	});
+
+	return serialised.length > 0 ? serialised : undefined;
+}
 
 function normaliseMessageParts(parts: unknown): Message["parts"] | undefined {
 	if (!Array.isArray(parts)) {
@@ -276,8 +302,9 @@ export function serialiseMessageForConversationUpdate(message: Message): Convers
 		requestMessage.tool_calls = toolCalls;
 	}
 
-	if (Array.isArray(normalizedMessage.citations)) {
-		requestMessage.citations = normalizedMessage.citations;
+	const citations = serialiseCitationsForConversationUpdate(normalizedMessage.citations);
+	if (citations) {
+		requestMessage.citations = citations;
 	}
 
 	return requestMessage;

--- a/apps/mobile/ios/Polychat/Models/APIModels.swift
+++ b/apps/mobile/ios/Polychat/Models/APIModels.swift
@@ -288,7 +288,28 @@ public struct TitleGenerationResponse: Codable {
 }
 
 public struct UpdateConversationRequest: Codable {
-    let title: String
+    let title: String?
+    let messages: [ChatRequestMessage]?
+    let parentConversationId: String?
+    let parentMessageId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case title, messages
+        case parentConversationId = "parent_conversation_id"
+        case parentMessageId = "parent_message_id"
+    }
+
+    init(
+        title: String? = nil,
+        messages: [ChatMessage]? = nil,
+        parentConversationId: String? = nil,
+        parentMessageId: String? = nil
+    ) {
+        self.title = title
+        self.messages = messages?.map(ChatRequestMessage.init)
+        self.parentConversationId = parentConversationId
+        self.parentMessageId = parentMessageId
+    }
 }
 
 public struct UpdateConversationResponse: Codable {

--- a/apps/mobile/ios/Polychat/Models/ChatRequestMessage.swift
+++ b/apps/mobile/ios/Polychat/Models/ChatRequestMessage.swift
@@ -7,6 +7,11 @@ struct ChatRequestMessage: Encodable {
     let data: ChatMessageData?
     let name: String?
     let parts: [ChatMessagePart]?
+    let model: String?
+    let citations: [ChatCitation]?
+    let status: String?
+    let logId: String?
+    let timestamp: Double?
 
     init(message: ChatMessage) {
         self.id = message.id
@@ -15,10 +20,16 @@ struct ChatRequestMessage: Encodable {
         self.data = message.data
         self.name = message.name
         self.parts = message.parts
+        self.model = message.model
+        self.citations = message.citations
+        self.status = message.status
+        self.logId = message.logId
+        self.timestamp = message.timestamp
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, role, content, data, name, parts
+        case id, role, content, data, name, parts, model, citations, status, timestamp
+        case logId = "log_id"
     }
 }
 

--- a/apps/mobile/ios/Polychat/Services/APIClient.swift
+++ b/apps/mobile/ios/Polychat/Services/APIClient.swift
@@ -161,11 +161,22 @@ final class APIClient: ObservableObject {
         )
     }
 
-    func updateConversation(id: String, title: String) async throws {
+    func updateConversation(
+        id: String,
+        title: String? = nil,
+        messages: [ChatMessage]? = nil,
+        parentConversationId: String? = nil,
+        parentMessageId: String? = nil
+    ) async throws {
         let _: EmptyResponse = try await send(
             path: "/chat/completions/\(id)",
             method: "PUT",
-            body: UpdateConversationRequest(title: title)
+            body: UpdateConversationRequest(
+                title: title,
+                messages: messages,
+                parentConversationId: parentConversationId,
+                parentMessageId: parentMessageId
+            )
         )
     }
 

--- a/apps/mobile/ios/Polychat/Services/APIClientProtocols.swift
+++ b/apps/mobile/ios/Polychat/Services/APIClientProtocols.swift
@@ -19,11 +19,21 @@ protocol ConversationAPIClient {
         settings: ChatSettings?
     ) -> AsyncThrowingStream<ChatStreamEvent, Error>
     func generateTitle(conversationId: String, messages: [ChatMessage]) async throws -> TitleGenerationResponse
-    func updateConversation(id: String, title: String) async throws
+    func updateConversation(id: String, title: String?, messages: [ChatMessage]?, parentConversationId: String?, parentMessageId: String?) async throws
     func deleteConversation(id: String) async throws
 }
 
 extension ConversationAPIClient {
+    func updateConversation(id: String, title: String) async throws {
+        try await updateConversation(
+            id: id,
+            title: title,
+            messages: nil,
+            parentConversationId: nil,
+            parentMessageId: nil
+        )
+    }
+
     func fetchConversations() async throws -> ConversationListResponse {
         try await fetchConversations(limit: 50, page: 1, includeArchived: false)
     }

--- a/apps/mobile/ios/Polychat/Services/ConversationManager.swift
+++ b/apps/mobile/ios/Polychat/Services/ConversationManager.swift
@@ -174,6 +174,74 @@ class ConversationManager: ObservableObject {
         )
     }
 
+
+    func branchConversation(from messageId: String, settings: ChatSettings? = nil) async {
+        guard let parentConversation = currentConversation else {
+            error = "Unable to branch: conversation not found"
+            return
+        }
+
+        guard let messageIndex = parentConversation.messages.firstIndex(where: { $0.id == messageId }) else {
+            error = "Unable to branch: message not found"
+            return
+        }
+
+        let branchMessage = parentConversation.messages[messageIndex]
+        guard branchMessage.role == "user" || branchMessage.role == "assistant" else {
+            error = "Only user and assistant messages can start a branch"
+            return
+        }
+
+        let branchMessages = Array(parentConversation.messages.prefix(messageIndex + 1))
+        let branchId = UUID().uuidString
+        var branch = Conversation(
+            id: branchId,
+            title: parentConversation.title.isEmpty ? "Branched Conversation" : parentConversation.title,
+            messages: branchMessages,
+            createdAt: Date(),
+            modelId: parentConversation.modelId,
+            isLoadedFromAPI: false,
+            lastMessageAt: Date(),
+            messageCount: branchMessages.count
+        )
+
+        conversations.insert(branch, at: 0)
+        currentConversation = branch
+
+        if parentConversation.isLoadedFromAPI {
+            do {
+                guard let apiClient else {
+                    throw NSError(domain: "com.polychat.app", code: 1,
+                                  userInfo: [NSLocalizedDescriptionKey: "API client not configured"])
+                }
+
+                try await apiClient.updateConversation(
+                    id: branchId,
+                    title: branch.title,
+                    messages: branchMessages,
+                    parentConversationId: parentConversation.id,
+                    parentMessageId: messageId
+                )
+                branch.isLoadedFromAPI = true
+                updateConversationInArray(branch)
+                if currentConversation?.id == branchId {
+                    currentConversation = branch
+                }
+            } catch {
+                self.error = "Branch was created locally, but could not be synced: \(error.localizedDescription)"
+            }
+        }
+
+        if branchMessage.role == "user" {
+            await generateAssistantResponse(
+                conversationId: branchId,
+                requestMessages: branchMessages,
+                settings: settings,
+                generateTitle: true
+            )
+        }
+    }
+
     func regenerateAssistantMessage(_ messageId: String, settings: ChatSettings? = nil) async {
         guard let conversation = currentConversation,
               let messageIndex = conversation.messages.firstIndex(where: { $0.id == messageId }) else {
@@ -271,7 +339,9 @@ class ConversationManager: ObservableObject {
         conversation.messages.append(loadingMessage)
         conversation.lastMessageAt = Date()
         conversation.messageCount = conversation.messages.count
-        currentConversation = conversation
+        if currentConversation?.id == conversationId {
+            currentConversation = conversation
+        }
         updateConversationInArray(conversation)
 
         var finalMessageId = assistantMessageId

--- a/apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift
+++ b/apps/mobile/ios/Polychat/Views/Chat/MessageBubble.swift
@@ -55,7 +55,7 @@ struct MessageBubble: View {
                         .background(messageBackground)
                 }
 
-                if !message.renderedTextContent.isEmpty && !message.renderedTextContent.hasPrefix("Error:") {
+                if shouldShowActions {
                     HStack(spacing: 12) {
                         if message.role == "assistant" {
                             Button(action: regenerateMessage) {
@@ -73,6 +73,15 @@ struct MessageBubble: View {
                                     .foregroundColor(.secondary)
                             }
                             .accessibilityLabel("Edit message")
+                        }
+
+                        if canBranch {
+                            Button(action: branchConversation) {
+                                Image(systemName: "arrow.triangle.branch")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                            .accessibilityLabel("Branch conversation")
                         }
 
                         Button(action: copyMessage) {
@@ -123,6 +132,14 @@ struct MessageBubble: View {
         }
 
         return modelsStore.model(withId: assistantModelId)
+    }
+
+    private var shouldShowActions: Bool {
+        !message.renderedTextContent.isEmpty
+    }
+
+    private var canBranch: Bool {
+        message.role == "user" || message.role == "assistant"
     }
 
     private var displayContent: String {
@@ -176,6 +193,12 @@ struct MessageBubble: View {
         let newText = editedMessageText
         Task {
             await conversationManager.editUserMessage(message.id, text: newText)
+        }
+    }
+
+    private func branchConversation() {
+        Task {
+            await conversationManager.branchConversation(from: message.id)
         }
     }
 

--- a/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
+++ b/apps/mobile/ios/PolychatTests/ServiceStoreTests.swift
@@ -216,6 +216,71 @@ struct ServiceStoreTests {
         #expect(manager.currentConversation?.messages.first?.textContent == "Updated caption")
     }
 
+
+    @MainActor
+    @Test func conversationManagerBranchesAssistantMessageWithoutRegenerating() async throws {
+        let apiClient = ConversationAPIClientStub()
+        let manager = ConversationManager()
+        manager.configure(apiClient: apiClient)
+        let parent = makeConversation(
+            id: "parent-1",
+            title: "Original",
+            messages: [
+                ChatMessage(id: "user-1", role: "user", content: "Question"),
+                ChatMessage(id: "assistant-1", role: "assistant", content: "Answer"),
+                ChatMessage(id: "user-2", role: "user", content: "Follow up")
+            ],
+            isLoadedFromAPI: true
+        )
+        manager.conversations = [parent]
+        manager.currentConversation = parent
+
+        await manager.branchConversation(from: "assistant-1")
+
+        let branch = try #require(manager.currentConversation)
+        #expect(branch.id != "parent-1")
+        #expect(branch.title == "Original")
+        #expect(branch.messages.map(\.id) == ["user-1", "assistant-1"])
+        #expect(branch.isLoadedFromAPI)
+        #expect(apiClient.streamCallCount == 0)
+        #expect(apiClient.updatedConversationPayloads.first?.id == branch.id)
+        #expect(apiClient.updatedConversationPayloads.first?.messages?.map(\.id) == ["user-1", "assistant-1"])
+        #expect(apiClient.updatedConversationPayloads.first?.parentConversationId == "parent-1")
+        #expect(apiClient.updatedConversationPayloads.first?.parentMessageId == "assistant-1")
+    }
+
+    @MainActor
+    @Test func conversationManagerBranchesUserMessageAndGeneratesResponse() async throws {
+        let apiClient = ConversationAPIClientStub()
+        apiClient.streamEvents = [
+            .content("Branched answer"),
+            .done
+        ]
+        let manager = ConversationManager()
+        manager.configure(apiClient: apiClient)
+        let parent = makeConversation(
+            id: "parent-1",
+            title: "Original",
+            messages: [
+                ChatMessage(id: "user-1", role: "user", content: "Question"),
+                ChatMessage(id: "assistant-1", role: "assistant", content: "Answer")
+            ],
+            isLoadedFromAPI: false
+        )
+        manager.conversations = [parent]
+        manager.currentConversation = parent
+
+        await manager.branchConversation(from: "user-1")
+
+        let branch = try #require(manager.currentConversation)
+        #expect(branch.id != "parent-1")
+        #expect(apiClient.streamCallCount == 1)
+        #expect(apiClient.streamedCompletionId == branch.id)
+        #expect(apiClient.streamedMessages.map(\.id) == ["user-1"])
+        #expect(branch.messages.map(\.role) == ["user", "assistant"])
+        #expect(branch.messages.last?.textContent == "Branched answer")
+    }
+
     @MainActor
     @Test func conversationManagerPersistsRenamedLoadedConversation() async throws {
         let apiClient = ConversationAPIClientStub()

--- a/apps/mobile/ios/PolychatTests/TestSupport.swift
+++ b/apps/mobile/ios/PolychatTests/TestSupport.swift
@@ -95,6 +95,7 @@ final class ConversationAPIClientStub: ConversationAPIClient {
     var streamedCompletionId: String?
     var streamCallCount = 0
     var updatedConversationTitles: [(id: String, title: String)] = []
+    var updatedConversationPayloads: [(id: String, title: String?, messages: [ChatMessage]?, parentConversationId: String?, parentMessageId: String?)] = []
     var deletedConversationIds: [String] = []
     var generatedTitle = "Generated title"
 
@@ -130,8 +131,23 @@ final class ConversationAPIClientStub: ConversationAPIClient {
         TitleGenerationResponse(title: generatedTitle)
     }
 
-    func updateConversation(id: String, title: String) async throws {
-        updatedConversationTitles.append((id: id, title: title))
+    func updateConversation(
+        id: String,
+        title: String?,
+        messages: [ChatMessage]?,
+        parentConversationId: String?,
+        parentMessageId: String?
+    ) async throws {
+        updatedConversationPayloads.append((
+            id: id,
+            title: title,
+            messages: messages,
+            parentConversationId: parentConversationId,
+            parentMessageId: parentMessageId
+        ))
+        if let title {
+            updatedConversationTitles.append((id: id, title: title))
+        }
     }
 
     func deleteConversation(id: String) async throws {


### PR DESCRIPTION
### Motivation

- Bring web app conversation branching features to the iOS app so users can branch from either user or assistant messages and preserve branch history and parent metadata. 
- Ensure background streaming/generation updates the intended conversation without stealing the active chat when the user has navigated away.

### Description

- Add `branchConversation(from:settings:)` to `ConversationManager` to create branched conversations from a user or assistant message, insert the branch locally, optionally persist it via the conversation update API, and only generate a new assistant response when branching from a user message. 
- Extend mobile API models and client to support sending `messages` plus `parent_conversation_id` and `parent_message_id` when updating a conversation by updating `UpdateConversationRequest`, `APIClient.updateConversation(...)`, and the `ConversationAPIClient` protocol. 
- Expand `ChatRequestMessage` serialization to include `model`, `citations`, `status`, `log_id`, and `timestamp` so branch persistence retains message metadata. 
- Update streaming behavior in `ConversationManager.generateAssistantResponse` to only update `currentConversation` if the streaming response targets the active conversation, preventing background streams from stealing focus. 
- Surface message actions for error responses and add a Branch button to `MessageBubble` so users can branch or retry/copy failed replies. 
- Add unit tests for branching behavior and extend the test API client stub to capture the updated conversation payloads for verification.

### Testing

- Verified parsing/compilation of modified Swift sources using `swiftc -parse` on model, service, view, and test files (parse runs completed successfully). 
- Ran additional `swiftc -parse` invocations including test files and service stubs to validate the new signatures and test helpers (completed successfully). 
- Ran `git diff --check` to ensure no whitespace or diff-check failures (no issues found). 
- Attempted platform tests: `xcodebuild test` is unavailable in this environment so full Xcode test execution could not be run here; `swift test` was not applicable to the Xcode project.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ac747850832a948a14379cac5984)