### PR TITLE
Potential fix for code scanning alert no. 30: Inefficient regular expression

### DIFF
--- a/apps/api/src/lib/chat/utils.ts
+++ b/apps/api/src/lib/chat/utils.ts
@@ -227,7 +227,7 @@ export function sanitiseInput(input: string): string {
 		.replace(/}}/g, "} }")
 		// Handle angle brackets that might be part of XML-style instructions
 		.replace(
-			/<([a-zA-Z][a-zA-Z0-9]*(\s+[a-zA-Z][a-zA-Z0-9]*=("[^"]*"|'[^']*'|[^>\s]+))*)\s*\/?>/g,
+			/<([a-zA-Z][a-zA-Z0-9]*(\s+[a-zA-Z][a-zA-Z0-9]*=("[^"]*"|'[^']*'|[^>"'\s]+))*)\s*\/?>/g,
 			"`&lt;$1&gt;`",
 		)
 		// Normalize whitespace (but preserve newlines)


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/ai-platform/security/code-scanning/30](https://github.com/nicholasgriffintn/ai-platform/security/code-scanning/30)

The best fix is to make the alternation branches mutually exclusive so the engine does not have to explore exponentially many paths. In this regex, the unquoted branch `[^>\s]+` is the source of overlap because it can start with quotes and consume text intended for quoted branches. Restrict it to exclude both quote characters: `[^>"'\s]+`.

Apply this in `apps/api/src/lib/chat/utils.ts` at the regex replacement around line 230. No behavior change is intended beyond regex performance safety: quoted values still match via quoted branches, and unquoted values still match unless they contain forbidden delimiters (`>`, whitespace, quotes), which is consistent with attribute parsing expectations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
