### PR TITLE
Potential fix for code scanning alert no. 46: Replacement of a substring with itself

### DIFF
--- a/apps/app/src/lib/recipe-composio-trigger-configuration.ts
+++ b/apps/app/src/lib/recipe-composio-trigger-configuration.ts
@@ -141,7 +141,7 @@ export function buildRecipeTriggerConfiguration(
 	if (errors.length > 0) {
 		return {
 			configuration: {},
-			error: `${errors.join(" and ").replace(" and enter", " and enter")}.`,
+			error: `${errors.join(" and ")}.`,
 		};
 	}
 	return { configuration };


### PR DESCRIPTION
Potential fix for [https://github.com/nicholasgriffintn/ai-platform/security/code-scanning/46](https://github.com/nicholasgriffintn/ai-platform/security/code-scanning/46)

The best fix is to remove the redundant `.replace(" and enter", " and enter")` call and return the joined error text directly with the period suffix.

In `apps/app/src/lib/recipe-composio-trigger-configuration.ts`, update the return statement inside `if (errors.length > 0)` (around line 144) so that:

- `error` becomes `` `${errors.join(" and ")}.` ``.
- No imports, helper methods, or additional definitions are needed.
- Functionality is preserved (output text remains the same as currently produced), while eliminating dead/no-op code and the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
