### PR TITLE
chore(chat): remove comments from the lib/chat refactor

### DIFF
--- a/apps/api/src/lib/chat/messages/attachments.ts
+++ b/apps/api/src/lib/chat/messages/attachments.ts
@@ -63,10 +63,6 @@ export function parseAttachments(contents: readonly unknown[]): ParsedAttachment
   };
 }
 
-/**
- * Deduplicate on URL or markdown body; an attachment with neither is unaddressable
- * and dropped rather than kept as a blank duplicate.
- */
 export function dedupeAttachments(attachments: Attachment[]): Attachment[] {
   const seen = new Set<string>();
 

--- a/apps/api/src/lib/chat/messages/sanitise.ts
+++ b/apps/api/src/lib/chat/messages/sanitise.ts
@@ -1,10 +1,6 @@
 import type { Message } from "~/types/chat";
 import { sanitiseInput } from "~/utils/sanitise";
 
-/**
- * Only user and developer turns carry untrusted text; assistant and tool turns
- * are our own output and must survive unmodified.
- */
 export function sanitiseMessages(messages: Message[]): Message[] {
   return messages.map((msg) => {
     if (msg.role === "user" || msg.role === "developer") {

--- a/apps/api/src/lib/chat/policy/context-window.ts
+++ b/apps/api/src/lib/chat/policy/context-window.ts
@@ -12,10 +12,6 @@ function resolveContextWindow(modelConfig: ContextWindowSource): number {
   return modelConfig?.contextWindow || FALLBACK_CONTEXT_WINDOW;
 }
 
-/**
- * Guard the request before it reaches a provider. Pruning runs first at every call
- * site, so this only fires when the incoming content alone overruns the window.
- */
 export function checkContextWindowLimits(
   messages: Message[],
   newContent: string,
@@ -34,9 +30,6 @@ export function checkContextWindowLimits(
   }
 }
 
-/**
- * Drop whole messages from the front until the history plus the incoming content fits.
- */
 export function pruneMessagesToFitContext(
   messages: Message[],
   newContent: string,

--- a/apps/api/src/utils/sanitise.ts
+++ b/apps/api/src/utils/sanitise.ts
@@ -1,7 +1,3 @@
-/**
- * Strip prompt-injection vectors from untrusted text before it reaches a provider.
- * Code blocks are lifted out first so fenced examples survive verbatim.
- */
 export function sanitiseInput(input: string): string {
   const codeBlocks: string[] = [];
   let codeBlockCount = 0;
@@ -16,20 +12,15 @@ export function sanitiseInput(input: string): string {
   });
 
   const sanitised = withoutCodeBlocks
-    // Remove instruction formats
     .replace(/<\/?(?:INST|system|assistant|human|user|ai)[^>]*>/gi, "")
     .replace(/\[\/?(?:INST|system|assistant|human|user|ai)\]/gi, "")
-    // Remove sentinel tokens
     .replace(/<\/?s>/gi, "")
-    // Escape template syntax
     .replace(/{{/g, "{ {")
     .replace(/}}/g, "} }")
-    // Handle angle brackets that might be part of XML-style instructions
     .replace(
       /<([a-zA-Z][a-zA-Z0-9]*(\s+[a-zA-Z][a-zA-Z0-9]*=("[^"]*"|'[^']*'|[^>"'\s]+))*)\s*\/?>/g,
       "`&lt;$1&gt;`",
     )
-    // Normalize whitespace (but preserve newlines)
     .replace(/[ \t]+/g, " ");
 
   const result = sanitised.replace(/__CODE_BLOCK_(\d+)__/g, (_, index) => {


### PR DESCRIPTION
Deletions only, 24 lines across 4 files.

#2047 added doc comments to the modules split out of `utils.ts`, and carried over the inline annotations that file already had (`// Remove sentinel tokens` and friends). This repo does not use explanatory comments; I added them anyway.

- `apps/api/src/utils/sanitise.ts`
- `apps/api/src/lib/chat/messages/attachments.ts`
- `apps/api/src/lib/chat/messages/sanitise.ts`
- `apps/api/src/lib/chat/policy/context-window.ts`

No behaviour change. Typecheck clean, 783 tests passing, lint and format clean.

The equivalent 56 lines in #2049 are already stripped on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
